### PR TITLE
Changed format of CSS in HTML5 boilerplate styles

### DIFF
--- a/djangocms_admin_style/sass/djangocms-admin-frontend.scss
+++ b/djangocms_admin_style/sass/djangocms-admin-frontend.scss
@@ -1,4 +1,12 @@
-#header, .breadcrumbs { display: none; }
-.login #header { display: block; }
+#header,
+.breadcrumbs {
+    display: none;
+}
 
-form select { max-width: 240px; }
+.login #header {
+    display: block;
+}
+
+form select {
+    max-width: 240px;
+}

--- a/djangocms_admin_style/sass/djangocms-admin.scss
+++ b/djangocms_admin_style/sass/djangocms-admin.scss
@@ -14,6 +14,7 @@
 // TODO:
 //@import "partials/_messages.scss";
 
-@media only screen and (max-width: 420px), print {
+@media only screen and (max-width: 420px),
+print {
 	@import "partials/_mobile.scss";
 }

--- a/djangocms_admin_style/sass/libs/html5-boilerplate/_fonts.scss
+++ b/djangocms_admin_style/sass/libs/html5-boilerplate/_fonts.scss
@@ -8,20 +8,26 @@ $base-line-height: 1.231 !default;
 //
 
 @mixin html5-boilerplate-fonts($family: $base-font-family, $size: $base-font-size, $line-height: $base-line-height) {
-	body {
-		font-size: $size;
-		font-family: $family;
-		line-height: $line-height; // hack retained to preserve specificity
-		*font-size: small;
-	}
 
-	// Normalize monospace sizing:
-	// en.wikipedia.org/wiki/MediaWiki_talk:Common.css/Archive_11#Teletype_style_fix_for_Chrome
-	pre, code, kbd, samp { font-family: monospace, sans-serif; }
+	body {
+        font-size: $size;
+        font-family: $family;
+        line-height: $line-height;
+        // hack retained to preserve specificity
+        *font-size: small;
+    }
+    // Normalize monospace sizing:
+    // en.wikipedia.org/wiki/MediaWiki_talk:Common.css/Archive_11#Teletype_style_fix_for_Chrome
+    pre,
+	code,
+	kbd,
+	samp {
+        font-family: monospace, sans-serif;
+    }
 }
 
 @mixin font-smoothing {
-	@warn "The 'font-smoothing' mixin has been deprecated as it made monospace too thin.";
+    @warn "The 'font-smoothing' mixin has been deprecated as it made monospace too thin.";
 }
 
 // Sets the font size specified in pixels using percents so that the base
@@ -38,5 +44,5 @@ $base-line-height: 1.231 !default;
 //
 // For more information see the table found at http://developer.yahoo.com/yui/3/cssfonts/#fontsize
 @mixin font-size($size, $base-font-size: $base-font-size) {
-	font-size: ceil(percentage($size / $base-font-size));
+    font-size: ceil(percentage($size / $base-font-size));
 }

--- a/djangocms_admin_style/sass/libs/html5-boilerplate/_helpers.scss
+++ b/djangocms_admin_style/sass/libs/html5-boilerplate/_helpers.scss
@@ -7,64 +7,96 @@
 //
 
 @mixin html5-boilerplate-helpers {
-	.ir { @include image-replacement; }
+    .ir {
+        @include image-replacement;
+    }
 
-	.hidden { @include hidden; }
+    .hidden {
+        @include hidden;
+    }
 
-	.visuallyhidden { @include visually-hidden; }
+    .visuallyhidden {
+        @include visually-hidden;
+    }
 
-	.clearfix { @include micro-clearfix; }
+    .clearfix {
+        @include micro-clearfix;
+    }
 }
 
 // Almost the same as compass replace-text
 // but adding direction: ltr
 @mixin image-replacement($img: none, $x: 50%, $y: 50%) {
-	@include hide-text;
-	direction: ltr;
-	background-repeat: no-repeat;
+    @include hide-text;
+    direction: ltr;
+    background-repeat: no-repeat;
+
 	@if $img != none {
-		background-image: image-url($img);
-		background-position: $x $y;
-	}
+        background-image: image-url($img);
+        background-position: $x $y;
+    }
 }
 
 @mixin sized-image-replacement($img, $x: 50%, $y: 50%) {
-	@include image-replacement($img, $x, $y);
-	width: image-width($img);
-	height: image-height($img);
+    @include image-replacement($img, $x, $y);
+    width: image-width($img);
+    height: image-height($img);
 }
 
 // Hide for both screenreaders and browsers
 // css-discuss.incutio.com/wiki/Screenreader_Visibility
 @mixin hidden {
-	display:none;
-	visibility: hidden;
+    display: none;
+    visibility: hidden;
 }
 
 // Hide only visually, but have it available for screenreaders: by Jon Neal
 // www.webaim.org/techniques/css/invisiblecontent/  &  j.mp/visuallyhidden
 @mixin visually-hidden {
-	border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+
 	// Extends the .visuallyhidden class to allow the element to be focusable
-	// when navigated to via the keyboard: drupal.org/node/897638
-	&.focusable:active, &.focusable:focus {
-		clip: auto; height: auto; margin: 0; overflow: visible; position: static; width: auto;
-	}
+    // when navigated to via the keyboard: drupal.org/node/897638
+    &.focusable:active,
+	&.focusable:focus {
+        clip: auto;
+        height: auto;
+        margin: 0;
+        overflow: visible;
+        position: static;
+        width: auto;
+    }
 }
 
 // Hide visually and from screenreaders, but maintain layout
-@mixin invisible { visibility: hidden; }
+@mixin invisible {
+    visibility: hidden;
+}
 
 // The Magnificent Clearfix: Updated to prevent margin-collapsing on child elements in most situations.
 // nicolasgallagher.com/micro-clearfix-hack/
 @mixin micro-clearfix {
-	&:before, &:after { content: ""; display: table; }
-	&:after { clear: both; }
-	zoom: 1;
+
+	&:before,
+	&:after {
+        content: "";
+        display: table;
+    }
+    &:after {
+        clear: both;
+    }
+    zoom: 1;
 }
 
 // The Magnificent CLEARFIX << j.mp/phayesclearfix
 @mixin magnificent-clearfix {
-	@warn "The 'magnificent-clearfix' mixin has been deprecated. Use 'pie-clearfix' in compass core instead.";
-	@include pie-clearfix;
+    @warn "The 'magnificent-clearfix' mixin has been deprecated. Use 'pie-clearfix' in compass core instead.";
+    @include pie-clearfix;
 }

--- a/djangocms_admin_style/sass/libs/html5-boilerplate/_media.scss
+++ b/djangocms_admin_style/sass/libs/html5-boilerplate/_media.scss
@@ -1,5 +1,5 @@
 @mixin html5-boilerplate-media {
-	@warn "The 'html5-boilerplate-media' mixin has been deprecated.";
+    @warn "The 'html5-boilerplate-media' mixin has been deprecated.";
 }
 
 //
@@ -7,29 +7,82 @@
 // Inlined to avoid required HTTP connection www.phpied.com/delay-loading-your-print-css/
 
 @mixin media-print {
-	* { background: transparent !important; color: black !important; text-shadow: none !important; filter:none !important;
-	-ms-filter: none !important; } // Black prints faster: sanbeiji.com/archives/953
-	a, a:visited { color: #444 !important; text-decoration: underline; }
-	a[href]:after { content: " (" attr(href) ")"; }
-	abbr[title]:after { content: " (" attr(title) ")"; }
-	.ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after { content: ""; }  // Don't show links for images, or javascript/internal links
-	pre, blockquote { border: 1px solid #999; page-break-inside: avoid; }
-	thead { display: table-header-group; } // css-discuss.incutio.com/wiki/Printing_Tables
-	tr, img { page-break-inside: avoid; }
-	img { max-width: 100% !important; }
-	@page { margin: 0.5cm; }
-	p, h2, h3 { orphans: 3; widows: 3; }
-	h2, h3{ page-break-after: avoid; }
+
+	* {
+        background: transparent !important;
+        color: black !important;
+        text-shadow: none !important;
+        filter: none !important;
+        -ms-filter: none !important;
+    }
+	
+    // Black prints faster: sanbeiji.com/archives/953
+    a,
+	a:visited {
+        color: #444 !important;
+        text-decoration: underline;
+    }
+
+    a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    abbr[title]:after {
+        content: " (" attr(title) ")";
+    }
+
+    .ir a:after,
+	a[href^="javascript:"]:after,
+	a[href^="#"]:after {
+        content: "";
+    }
+
+    // Don't show links for images, or javascript/internal links
+    pre,
+	blockquote {
+        border: 1px solid #999;
+        page-break-inside: avoid;
+    }
+
+    thead {
+        display: table-header-group;
+    }
+
+    // css-discuss.incutio.com/wiki/Printing_Tables
+    tr,
+	img {
+        page-break-inside: avoid;
+    }
+
+    img {
+        max-width: 100% !important;
+    }
+
+    @page {
+        margin: 0.5cm;
+    }
+
+    p,
+	h2,
+	h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h2,
+	h3 {
+        page-break-after: avoid;
+    }
 }
 
 @mixin media-orientation-portrait {
-	@warn "The 'media-orientation-portrait' mixin has been deprecated.";
+    @warn "The 'media-orientation-portrait' mixin has been deprecated.";
 }
 
 @mixin media-orientation-landscape {
-	@warn "The 'media-orientation-landscape' mixin has been deprecated.";
+    @warn "The 'media-orientation-landscape' mixin has been deprecated.";
 }
 
 @mixin media-mobile($optimize: true) {
-	@warn "The 'media-mobile' mixin has been deprecated.";
+    @warn "The 'media-mobile' mixin has been deprecated.";
 }

--- a/djangocms_admin_style/sass/libs/html5-boilerplate/_reset.scss
+++ b/djangocms_admin_style/sass/libs/html5-boilerplate/_reset.scss
@@ -24,20 +24,49 @@
 		display: block;
 	}
 
-	blockquote, q { quotes: none; }
+	blockquote, q {
+		quotes: none;
+	}
 
 	blockquote:before, blockquote:after,
-	q:before, q:after { content: ""; content: none; }
+	q:before, q:after {
+		content: "";
+		content: none;
+	}
 
-	ins { background-color: #ff9; color: #000; text-decoration: none; }
+	ins {
+		background-color: #ff9;
+		color: #000;
+		text-decoration: none;
+	}
 
-	mark { background-color: #ff9; color: #000; font-style: italic; font-weight: bold; }
+	mark {
+		background-color: #ff9;
+		color: #000;
+		font-style: italic;
+		font-weight: bold;
+	}
 
-	del { text-decoration: line-through; }
+	del {
+		text-decoration: line-through;
+	}
 
-	abbr[title], dfn[title] { border-bottom: 1px dotted; cursor: help; }
+	abbr[title], dfn[title] {
+		border-bottom: 1px dotted;
+		cursor: help;
+	}
 
-	table { border-collapse: collapse; border-spacing: 0; }
+	table {
+		border-collapse: collapse;
+		border-spacing: 0;
+	}
 
-	hr { display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin: 1em 0; padding: 0; }
+	hr {
+		display: block;
+		height: 1px;
+		border: 0;
+		border-top: 1px solid #ccc;
+		margin: 1em 0;
+		padding: 0;
+	}
 }

--- a/djangocms_admin_style/sass/libs/html5-boilerplate/_styles.scss
+++ b/djangocms_admin_style/sass/libs/html5-boilerplate/_styles.scss
@@ -12,16 +12,28 @@ $list-left-margin: 1.8em !default;
 //
 
 @mixin html5-boilerplate-styles {
-	html { @include force-scrollbar; }
+	html {
+		@include force-scrollbar;
+	}
 
-	ul, ol { margin-left: $list-left-margin; }
-	ol { list-style-type: decimal; }
+	ul, ol {
+		margin-left: $list-left-margin;
+	}
+	ol {
+		list-style-type: decimal;
+	}
 
-	td { vertical-align: top; }
+	td {
+		vertical-align: top;
+	}
 
-	sub { @include sub; }
+	sub {
+		@include sub;
+	}
 
-	sup { @include sup; }
+	sup {
+		@include sup;
+	}
 
 	@include accessible-focus;
 
@@ -42,21 +54,34 @@ $list-left-margin: 1.8em !default;
 
 // set sub, sup without affecting line-height: gist.github.com/413930
 @mixin sub{
-	font-size: 75%; line-height: 0; position: relative; bottom: -0.25em;
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	bottom: -0.25em;
 }
+
 @mixin sup{
-	font-size: 75%; line-height: 0; position: relative; top: -0.5em;
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	top: -0.5em;
 }
 
 // accessible focus treatment: people.opera.com/patrickl/experiments/keyboard/test
 @mixin accessible-focus {
-	a:hover, a:active { outline: none; }
+
+	a:hover, a:active {
+		outline: none;
+	}
 }
 
 // www.pathf.com/blogs/2008/05/formatting-quoted-code-in-blog-posts-css21-white-space-pre-wrap
 @mixin quoted-pre {
+
 	pre {
-		white-space: pre; white-space: pre-wrap; word-wrap: break-word;
+		white-space: pre;
+		white-space: pre-wrap;
+		word-wrap: break-word;
 		padding: 15px;
 	}
 }
@@ -68,7 +93,13 @@ $list-left-margin: 1.8em !default;
 
 // Hand cursor on clickable input elements
 @mixin hand-cursor-inputs {
-	label, input[type="button"], input[type="submit"], input[type="image"], button { cursor: pointer; }
+	label,
+	input[type="button"],
+	input[type="submit"],
+	input[type="image"],
+	button {
+		cursor: pointer;
+	}
 }
 
 @mixin reset-form-elements {
@@ -77,15 +108,28 @@ $list-left-margin: 1.8em !default;
 	//    Firefox adds a 1px margin above and below textareas
 	// 3) Set font-size to match <body>'s, and font-family to sans-serif
 	// 4) Align to baseline
-	button, input, select, textarea { width: auto; overflow: visible; margin: 0; font-size: 100%; font-family: sans-serif; vertical-align: baseline; }
+	button, input, select, textarea {
+		width: auto;
+		overflow: visible;
+		margin: 0;
+		font-size: 100%;
+		font-family: sans-serif;
+		vertical-align: baseline;
+	}
 
 	// 1) Remove default scrollbar in IE: www.sitepoint.com/blogs/2010/08/20/ie-remove-textarea-scrollbars/
 	// 2) Align to text-top
-	textarea { overflow: auto; vertical-align: text-top; }
+	textarea {
+		overflow: auto;
+		vertical-align: text-top;
+	}
 
 	// Remove extra padding and inner border in Firefox
 	input::-moz-focus-inner,
-	button::-moz-focus-inner { border: 0; padding: 0; }
+	button::-moz-focus-inner {
+		border: 0;
+		padding: 0;
+	}
 }
 
 @mixin webkit-reset-form-elements {
@@ -96,31 +140,56 @@ $list-left-margin: 1.8em !default;
 // No text-shadow: twitter.com/miketaylr/status/12228805301
 // Also: hot pink!
 @mixin selected-text {
-	::-moz-selection{ background:$selected-background-color; color: $selected-font-color; text-shadow: none; }
-	::selection { background: $selected-background-color; color: $selected-font-color; text-shadow: none; }
+
+	::-moz-selection {
+		background:$selected-background-color;
+		color: $selected-font-color;
+		text-shadow: none;
+	}
+
+	::selection {
+		background: $selected-background-color;
+		color: $selected-font-color;
+		text-shadow: none;
+	}
 }
 
 // j.mp/webkit-tap-highlight-color
 @mixin webkit-tap-highlight {
-	a:link { -webkit-tap-highlight-color: $selected-background-color; }
+
+	a:link {
+		-webkit-tap-highlight-color: $selected-background-color;
+	}
 }
 
 // 1) Always force a scrollbar in non-IE
 // 2) Remove iOS text size adjust without disabling user zoom:
 //    www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/
 @mixin force-scrollbar {
-	overflow-y: scroll; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;
+	overflow-y: scroll;
+	-webkit-text-size-adjust: 100%;
+	-ms-text-size-adjust: 100%;
 }
 
 @mixin ie-hacks {
 	// Bicubic resizing for non-native sized IMG:
 	// code.flickr.com/blog/2008/11/12/on-ui-quality-the-little-things-client-side-image-resizing/
-	.ie7 img { -ms-interpolation-mode: bicubic; }
+	.ie7 img {
+		-ms-interpolation-mode: bicubic;
+	}
 
-	.ie6 legend, .ie7 legend { margin-left: -7px; }
+	.ie6 legend,
+	.ie7 legend {
+		margin-left: -7px;
+	}
 }
 
 @mixin no-nav-margins {
 	// remove margins for navigation lists
-	nav ul, nav li { margin: 0; list-style:none; list-style-image: none; }
+	nav ul,
+	nav li {
+		margin: 0;
+		list-style:none;
+		list-style-image: none;
+	}
 }

--- a/djangocms_admin_style/sass/partials/_base.scss
+++ b/djangocms_admin_style/sass/partials/_base.scss
@@ -76,7 +76,8 @@ code {
     background: inherit;
     color: #666;
     font-size: 11px;
-    strong {
+
+	strong {
         color: #930;
     }
 }
@@ -86,7 +87,8 @@ pre {
     background: inherit;
     color: #666;
     font-size: 11px;
-    &.literal-block {
+
+	&.literal-block {
         background: #eee;
     }
 }

--- a/djangocms_admin_style/sass/partials/_base.scss
+++ b/djangocms_admin_style/sass/partials/_base.scss
@@ -1,43 +1,116 @@
 // base
 
-body { background: url('../img/bg-pattern-light.jpg') #efefef repeat !important; }
-
-body, select, input, textarea { color: $font-color; }
-
-h1 { font-size: 150%; color: $font-color-medium; font-weight: bold; margin: 20px 10px 10px;  }
-h2 { font-size: 130%; color: $font-color-medium; font-weight: bold; line-height: 1.75em;}
-h3 { font-size: 120%; color: $font-color; font-weight: bold; }
-h4 { font-size: 110%; color: $font-color-medium; font-weight: bold;}
-h5 { font-size: 100%; color: $font-color; }
-h6 { font-size: 100%; color: $font-color-medium; }
-
-a, a:link {
-	color: $link-color;
-	text-decoration: none;
-	&:visited { color: $link-visited-color; }
-	&:hover { color: $link-hover-color; text-decoration: underline; }
-	&:active { color: $link-active-color; }
+body {
+    background: url("../img/bg-pattern-light.jpg") #efefef repeat !important;
 }
 
-p { font-weight: normal; margin-bottom: 6px; }
+body,
+select,
+input,
+textarea {
+    color: $font-color;
+}
+
+h1 {
+    font-size: 150%;
+    color: $font-color-medium;
+    font-weight: bold;
+    margin: 20px 10px 10px;
+}
+
+h2 {
+    font-size: 130%;
+    color: $font-color-medium;
+    font-weight: bold;
+    line-height: 1.75em;
+}
+
+h3 {
+    font-size: 120%;
+    color: $font-color;
+    font-weight: bold;
+}
+
+h4 {
+    font-size: 110%;
+    color: $font-color-medium;
+    font-weight: bold;
+}
+
+h5 {
+    font-size: 100%;
+    color: $font-color;
+}
+
+h6 {
+    font-size: 100%;
+    color: $font-color-medium;
+}
+
+a,
+a:link {
+    color: $link-color;
+    text-decoration: none;
+
+	&:visited {
+        color: $link-visited-color;
+    }
+
+	&:hover {
+        color: $link-hover-color;
+        text-decoration: underline;
+    }
+
+	&:active {
+        color: $link-active-color;
+    }
+}
+
+p {
+    font-weight: normal;
+    margin-bottom: 6px;
+}
 
 code {
-	font-family: "Bitstream Vera Sans Mono", Monaco, "Courier New", Courier, monospace; background: inherit;
-	color: #666; font-size: 11px;
-	strong { color: #930; }
+    font-family: "Bitstream Vera Sans Mono", Monaco, "Courier New", Courier, monospace;
+    background: inherit;
+    color: #666;
+    font-size: 11px;
+    strong {
+        color: #930;
+    }
 }
 
 pre {
-	font-family: "Bitstream Vera Sans Mono", Monaco, "Courier New", Courier, monospace; background: inherit;
-	color: #666; font-size: 11px;
-	&.literal-block { background: #eee; }
+    font-family: "Bitstream Vera Sans Mono", Monaco, "Courier New", Courier, monospace;
+    background: inherit;
+    color: #666;
+    font-size: 11px;
+    &.literal-block {
+        background: #eee;
+    }
 }
 
-div hr { background: $line-color-light; margin: 20px 0; border: none; }
+div hr {
+    background: $line-color-light;
+    margin: 20px 0;
+    border: none;
+}
 
-strong { font-weight: bold; }
-.small, small { font-size: 85%; margin-top: 0; }
+strong {
+    font-weight: bold;
+}
 
-.clearfix:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
+.small,
+small {
+    font-size: 85%;
+    margin-top: 0;
+}
 
-
+.clearfix:after {
+    content: ".";
+    display: block;
+    height: 0;
+    clear: both;
+    visibility: hidden;
+}

--- a/djangocms_admin_style/sass/partials/_cmsplaceholders.scss
+++ b/djangocms_admin_style/sass/partials/_cmsplaceholders.scss
@@ -1,13 +1,27 @@
 .plugin-holder {
-	background: transparent url('../img/pluginlist-holder-bg.png') repeat-y !important;
-	h2 { margin-bottom: 0 !important; }
+    background: transparent url("../img/pluginlist-holder-bg.png") repeat-y !important;
+
+	h2 {
+        margin-bottom: 0 !important;
+    }
+
 	.plugin-list-holder {
-		width: 285px;
-		.text { width: 240px; }
+        width: 285px;
+
+		.text {
+            width: 240px;
+        }
+
 		ul.plugin-list li.active {
-			background: url('../img/bg-pattern-light.jpg') #efefef repeat;
-			&:hover { background: white url('../../cms/images/sitemap-li-bg.jpg') repeat-x 0px -100px; }
-		}
-	}
+            background: url("../img/bg-pattern-light.jpg") #efefef repeat;
+
+			&:hover {
+                background: white url("../../cms/images/sitemap-li-bg.jpg") repeat-x 0px -100px;
+            }
+        }
+    }
 }
-.plugin-editor > iframe { min-height: 600px; }
+
+.plugin-editor > iframe {
+    min-height: 600px;
+}

--- a/djangocms_admin_style/sass/partials/_content.scss
+++ b/djangocms_admin_style/sass/partials/_content.scss
@@ -1,207 +1,554 @@
-
 // containers
-#container { width: auto !important; min-width: 0 !important; }
-#content { width: auto !important; min-width: 0 !important; }
-#changelist { width: auto !important; }
+#container {
+    width: auto !important;
+    min-width: 0 !important;
+}
+
+#content {
+    width: auto !important;
+    min-width: 0 !important;
+}
+
+#changelist {
+    width: auto !important;
+}
 
 // module
 .module {
-	@include box(); margin-bottom: 10px; padding: 10px 15px 15px;
-	h2 { background: none; border-bottom: 1px solid $line-color-light; color: $font-color; font-size: 100%;
-		margin-bottom: 2px;	margin-top: 0; padding: 10px; }
+    @include box;
+    margin-bottom: 10px;
+    padding: 10px 15px 15px;
+
+	h2 {
+        background: none;
+        border-bottom: 1px solid $line-color-light;
+        color: $font-color;
+        font-size: 100%;
+        margin-bottom: 2px;
+        margin-top: 0;
+        padding: 10px;
+    }
+
 	caption {
-		background: none; color: $font-color-light; font-size: 130%; font-weight: bold;
-		line-height: 1.75em; margin: 0 0 5px 5px; padding: 0;
-		a.section, a.section:link, a.section:visited { color: $font-color-light; }
-	}
+        background: none;
+        color: $font-color-light;
+        font-size: 130%;
+        font-weight: bold;
+        line-height: 1.75em;
+        margin: 0 0 5px 5px;
+        padding: 0;
+
+		a.section,
+		a.section:link,
+		a.section:visited {
+            color: $font-color-light;
+        }
+    }
+
 	table {
-		margin: 0;
-		th { padding: 2px 5px !important; line-height: 13px; }
-		td { padding: 8px 5px; line-height: 13px; }
-	}
+        margin: 0;
+
+		th {
+            padding: 2px 5px !important;
+            line-height: 13px;
+        }
+
+		td {
+            padding: 8px 5px;
+            line-height: 13px;
+        }
+    }
 }
 
 // inlines
-.module h2, .module caption, .inline-group h2 { background: none; color: $font-color-dark; font-size: 16px; }
+.module h2,
+.module caption,
+.inline-group h2 {
+    background: none;
+    color: $font-color-dark;
+    font-size: 16px;
+}
+
 .inline-group {
-	border: 0; @include box(); padding: 10px 15px 15px;
+    border: 0;
+    @include box;
+    padding: 10px 15px 15px;
+
+    .module {
+        background: none !important;
+        @include border-radius(0);
+        @include box-shadow(none);
+        border: none !important;
+        padding: 0;
+
+        h2 {
+            margin-bottom: 10px;
+            padding-top: 0;
+            padding-bottom: 8px;
+        }
+
+        .add-row a {
+            border-bottom: none;
+            color: $button-green-dark-color;
+        }
+
+        .add-row td {
+            background: none;
+            border-bottom: none;
+        }
+
+		tr.add-row:hover {
+            background: none;
+        }
+
+		.form-row {
+            border-bottom: none !important;
+        }
+    }
+
 	.module {
-		background: none !important; @include border-radius(0); @include box-shadow(none); border: none !important;
-		padding: 0;
-		h2 { margin-bottom: 10px; padding-top: 0; padding-bottom: 8px; }
-		.add-row a { border-bottom: none; color: $button-green-dark-color; }
-		.add-row td { background: none; border-bottom: none; }
-		tr.add-row:hover { background: none; }
-		.form-row { border-bottom: none !important; }
-	}
-	.module { width: 100%; overflow: auto; }
+        width: 100%;
+        overflow: auto;
+    }
+
 	.add-row {
-		&, td { border-bottom: none; background: none !important; }
-		a { color: $button-green-dark-color; }
-	}
+
+		&,
+		td {
+            border-bottom: none;
+            background: none !important;
+        }
+
+		a {
+            color: $button-green-dark-color;
+        }
+    }
 }
+
 .inline-related {
-	margin-bottom: 5px;
-	h3 { background: none; border-bottom: none; }
+    margin-bottom: 5px;
+
+	h3 {
+        background: none;
+        border-bottom: none;
+    }
 }
+
 .submit-row {
-	@include border-radius(); border: 1px solid $line-color-light; padding: 10px;
-	@include box-shadow($background-color-white 0 0 $button-shadow-width inset !important);
-	background: $background-color-light;
-	background: $background-color-transparent !important;
-	.deletelink-box { line-height: 24px; }
-	.deletelink { @include button-common(); @include button-red(); }
-	input[type="submit"].default { margin-left: 10px; }
+    @include border-radius;
+    border: 1px solid $line-color-light;
+    padding: 10px;
+    @include box-shadow($background-color-white 0 0 $button-shadow-width inset !important);
+    background: $background-color-light;
+    background: $background-color-transparent !important;
+
+	.deletelink-box {
+        line-height: 24px;
+    }
+
+	.deletelink {
+        @include button-common;
+        @include button-red;
+    }
+
+	input[type="submit"].default {
+        margin-left: 10px;
+    }
 }
 
 // filter horizontal m2m
 .selector {
-	.selector-available, .selector-chosen {
-		@include border-radius(); border: 1px solid $line-color-light;
-		h2 { color: $font-color !important; background: none !important; border: none; margin-bottom: 0;
-			font-size: 13px; line-height: 16px; }
-		input { width: 252px; margin: -5px 0 2px 0; }
-	}
-	.selector-filter { border: none; }
-	.selector-filter label { display: none; }
-	select[multiple] { border: 1px solid $line-color-light; border-left: none; border-right: none;
-		margin-bottom: 0; }
+
+	.selector-available,
+	.selector-chosen {
+        @include border-radius;
+        border: 1px solid $line-color-light;
+
+		h2 {
+            color: $font-color !important;
+            background: none !important;
+            border: none;
+            margin-bottom: 0;
+            font-size: 13px;
+            line-height: 16px;
+        }
+
+		input {
+            width: 252px;
+            margin: -5px 0 2px 0;
+        }
+    }
+
+	.selector-filter {
+        border: none;
+    }
+
+	.selector-filter label {
+        display: none;
+    }
+
+	select[multiple] {
+        border: 1px solid $line-color-light;
+        border-left: none;
+        border-right: none;
+        margin-bottom: 0;
+    }
 }
 
 // login
 body.login {
-	background: $background-color-ultralight url('../img/bg-pattern.jpg') repeat !important;
+    background: $background-color-ultralight url("../img/bg-pattern.jpg") repeat !important;
+
 	#container {
-		@include box(); border: none; width: 340px !important;
-		@include box-shadow(rgba(0, 0, 0, 0.3) 0px 1px 2px, #fff 0px 1px 1px inset);
-		#header {
-			background: none !important;
-			#branding h1 { color: $font-color; margin: 20px 0 !important; text-align: center; }
-		}
-		#content {
-			margin: 0 !important; padding: 25px 40px !important;
-			#content-main {
-				form { margin-top: 0 !important; }
-				.form-row {
-					label { font-weight: normal; width: 100%; text-align: center; }
-					input { font-size: 16px; padding: 10px; width: 240px !important; }
-				}
-				.submit-row {
-					border: none; background: none; padding: 20px 0 0 0;
-					input, input[type="submit"] { background-image: none; @include button-blue();
-						width: 262px !important; }
-					label { display: none; }
-				}
-			}
-		}
-		#footer { display: none; }
-	}
+        @include box;
+        border: none;
+        width: 340px !important;
+        @include box-shadow(rgba(0, 0, 0, 0.3) 0px 1px 2px, white 0px 1px 1px inset);
+
+	    #header {
+            background: none !important;
+
+	        #branding h1 {
+                color: $font-color;
+                margin: 20px 0 !important;
+                text-align: center;
+            }
+        }
+
+	    #content {
+            margin: 0 !important;
+            padding: 25px 40px !important;
+
+	        #content-main {
+
+	            form {
+                    margin-top: 0 !important;
+                }
+
+	            .form-row {
+
+	                label {
+                        font-weight: normal;
+                        width: 100%;
+                        text-align: center;
+                    }
+
+	                input {
+                        font-size: 16px;
+                        padding: 10px;
+                        width: 240px !important;
+                    }
+                }
+
+	            .submit-row {
+                    border: none;
+                    background: none;
+                    padding: 20px 0 0 0;
+
+	                input,
+					input[type="submit"] {
+                        background-image: none;
+                        @include button-blue;
+                        width: 262px !important;
+                    }
+
+			        label {
+                        display: none;
+                    }
+                }
+            }
+        }
+
+		#footer {
+            display: none;
+        }
+    }
 }
 
 // header
 #header {
-	@include background-image(linear-gradient($background-color-dark, $background-color-medium));
-	background-color: $background-color-medium; color: $font-color-white !important; height: 46px;
-	#branding h1 { color: $font-color-white; padding: 3px 25px; }
-	#user-tools { padding: 16px 25px 0; }
+    @include background-image(linear-gradient($background-color-dark, $background-color-medium));
+    background-color: $background-color-medium;
+    color: $font-color-white !important;
+    height: 46px;
+
+    #branding h1 {
+        color: $font-color-white;
+        padding: 3px 25px;
+    }
+
+    #user-tools {
+        padding: 16px 25px 0;
+    }
 }
+
 div.breadcrumbs {
-	background: $background-color-dark; border-top: 1px solid $line-color-dark; color: #ddd; padding-left: 25px;
-	border-bottom: 0; padding-bottom: 4px;
-	a {
-		color: #bbb;
-		&:hover { color: $font-color-ultralight; text-decoration: none; }
-	}
+    background: $background-color-dark;
+    border-top: 1px solid $line-color-dark;
+    color: #ddd;
+    padding-left: 25px;
+    border-bottom: 0;
+    padding-bottom: 4px;
+
+    a {
+        color: #bbb;
+
+        &:hover {
+            color: $font-color-ultralight;
+            text-decoration: none;
+        }
+    }
 }
 
 // dashboard
 .dashboard #container {
-	#content-main {
-		min-width: 400px; max-width: 640px;
-		table th, table td {
-			width: auto; border-color: $line-color-ultralight;
-			a { line-height: 16px; }
-		}
-		table th { width: 100%; }
-		.module tr:first-child { th, td { border-top:1px solid $line-color-ultralight; } }
-	}
+
+    #content-main {
+        min-width: 400px;
+        max-width: 640px;
+
+        table th,
+		table td {
+            width: auto;
+            border-color: $line-color-ultralight;
+
+		    a {
+                line-height: 16px;
+            }
+        }
+
+		table th {
+            width: 100%;
+        }
+
+		.module tr:first-child {
+
+			th,
+			td {
+                border-top: 1px solid $line-color-ultralight;
+            }
+        }
+    }
+
 	#content-related {
-		float: left;
-		.module { @include border-radius(); border: 1px solid $line-color-light; margin-left: 10px;
-			@include box-shadow($background-color-white 0 0 $button-shadow-width inset !important);
-			background: $background-color-transparent !important; padding: 10px 20px !important;
-			ul.actionlist {
-				padding: 0;
-				.changelink a { line-height: 16px; }
-			}
-			h2 { background: none; color: $font-color-light; padding: 0 0 5px 0; }
-			h3 { border-bottom: 1px solid $line-color-light; line-height: 20px; margin: 0 0 5px 0; padding: 0; }
-			p { padding: 0; }
-		}
-	}
-	table tbody tr:hover { background: none; }
+        float: left;
+
+	    .module {
+            @include border-radius;
+            border: 1px solid $line-color-light;
+            margin-left: 10px;
+            @include box-shadow($background-color-white 0 0 $button-shadow-width inset !important);
+            background: $background-color-transparent !important;
+            padding: 10px 20px !important;
+
+	        ul.actionlist {
+                padding: 0;
+
+	            .changelink a {
+                    line-height: 16px;
+                }
+            }
+
+	        h2 {
+                background: none;
+                color: $font-color-light;
+                padding: 0 0 5px 0;
+            }
+
+	        h3 {
+                border-bottom: 1px solid $line-color-light;
+                line-height: 20px;
+                margin: 0 0 5px 0;
+                padding: 0;
+            }
+
+	        p {
+                padding: 0;
+            }
+        }
+    }
+
+	table tbody tr:hover {
+        background: none;
+    }
 }
 
 a.addlink {
-	&, &:link, &:visited { color: $button-green-medium-color; }
-	&:hover, &:focus, &:active { color: $button-green-dark-color; }
+
+	&,
+	&:link,
+	&:visited {
+        color: $button-green-medium-color;
+    }
+
+	&:hover,
+	&:focus,
+	&:active {
+        color: $button-green-dark-color;
+    }
 }
 
 // object tools
 .object-tools {
-	float:right; margin-top: -34px;
+    float: right;
+    margin-top: -34px;
+
 	li {
-		list-style: none; background: none; padding-left: 5px; height: 32px;
-		&:hover { background: none; }
-		> a { @include button-common(); }
-	}
-	.addlink { @include button-common(); @include button-green(); color: $button-green-font-color !important; }
-	.recoverlink { @include button-common(); }
-	.publishlink { @include button-common(); }
-	.previewdraftlink { @include button-common(); }
-	.revertlink { @include button-common(); }
-	.historylink { @include button-common(); }
-	.viewsitelink { @include button-common(); @include button-blue(); }
+        list-style: none;
+        background: none;
+        padding-left: 5px;
+        height: 32px;
+
+	    &:hover {
+            background: none;
+        }
+
+	    > a {
+            @include button-common;
+        }
+    }
+
+	.addlink {
+        @include button-common;
+        @include button-green;
+        color: $button-green-font-color !important;
+    }
+
+	.recoverlink {
+        @include button-common;
+    }
+
+	.publishlink {
+        @include button-common;
+    }
+
+	.previewdraftlink {
+        @include button-common;
+    }
+
+	.revertlink {
+        @include button-common;
+    }
+
+	.historylink {
+        @include button-common;
+    }
+
+	.viewsitelink {
+        @include button-common;
+        @include button-blue;
+    }
 }
 
 // changelist
 .change-list {
+
 	.filtered {
-		min-height: auto; background-image: none !important;
-		table { border: none; }
-	}
+        min-height: auto;
+        background-image: none !important;
+
+	    table {
+            border: none;
+        }
+    }
+
 	#changelist {
-		table {
-			tbody {
-				th, td {
-					a, a:link, a:visited, a:link:visited { color: $link-color; }
+
+	    table {
+
+	        tbody {
+
+	            th,
+				td {
+
+					a,
+					a:link,
+					a:visited,
+					a:link:visited {
+                        color: $link-color;
+                    }
+
 					border-color: $background-color-light;
-				}
-				tr.selected { background: $background-color-highlight !important; }
-			}
-		}
-		#toolbar {
-			background: none !important; border: 0 !important; margin: 0 0 5px 0; min-height: 30px; height: auto;
-			form label { min-width: auto; padding: 0; font-size: 100%; }
-			form #searchbar { padding: 6px 5px 8px 5px !important; font-size: 100%; }
-		}
-		#changelist-filter {
-			min-height: 100%; background: #fafafa; @include border-top-right-radius(); @include border-bottom-right-radius();
-			h2 { background: none; color: $font-color-light; padding: 2px 9px; }
-			h3 { margin: 5px 0; }
-			ul {
-				font-size: 12px; margin-bottom: 10px;
-				li { margin-bottom: 2px; }
-				li.selected a { color: $link-color !important; }
-			}
-		}
-		.actions {
-			background: none; border: none; padding: 0px 3px 10px 3px;
-			button { height: 20px; vertical-align: middle; padding-top: 2px !important; }
-		}
-		.toplinks { border-bottom: none !important; background: none; margin-bottom: 5px !important; }
-		.paginator { border: none; background: none; }
-	}
+                }
+
+                tr.selected {
+                    background: $background-color-highlight !important;
+                }
+            }
+        }
+
+        #toolbar {
+            background: none !important;
+            border: 0 !important;
+            margin: 0 0 5px 0;
+            min-height: 30px;
+            height: auto;
+
+            form label {
+                min-width: auto;
+                padding: 0;
+                font-size: 100%;
+            }
+
+            form #searchbar {
+                padding: 6px 5px 8px 5px !important;
+                font-size: 100%;
+            }
+        }
+
+        #changelist-filter {
+            min-height: 100%;
+            background: #fafafa;
+            @include border-top-right-radius;
+            @include border-bottom-right-radius;
+
+            h2 {
+                background: none;
+                color: $font-color-light;
+                padding: 2px 9px;
+            }
+
+            h3 {
+                margin: 5px 0;
+            }
+
+            ul {
+                font-size: 12px;
+                margin-bottom: 10px;
+
+                li {
+                    margin-bottom: 2px;
+                }
+
+                li.selected a {
+                    color: $link-color !important;
+                }
+            }
+        }
+
+        .actions {
+            background: none;
+            border: none;
+            padding: 0px 3px 10px 3px;
+
+            button {
+                height: 20px;
+                vertical-align: middle;
+                padding-top: 2px !important;
+            }
+        }
+
+        .toplinks {
+            border-bottom: none !important;
+            background: none;
+            margin-bottom: 5px !important;
+        }
+
+        .paginator {
+            border: none;
+            background: none;
+        }
+    }
 }
 
 // changeform
@@ -209,55 +556,145 @@ a.addlink {
 
 // delete page
 .delete-confirmation .colM {
-	@include box(); padding: 20px; margin: 15px !important;
-	h1 { margin: 0 0 10px 0; }
-	li { line-height: 16px; }
-	input[type="submit"] { @include button-red(); float: right; }
+    @include box;
+    padding: 20px;
+    margin: 15px !important;
+
+	h1 {
+        margin: 0 0 10px 0;
+    }
+
+	li {
+        line-height: 16px;
+    }
+
+	input[type="submit"] {
+        @include button-red;
+        float: right;
+    }
 }
 
 // cms pagelist
-#sitemap li a.addlink, #sitemap li a.deletelink { width: 11px; height: 11px; }
+#sitemap li a.addlink,
+#sitemap li a.deletelink {
+    width: 11px;
+    height: 11px;
+}
+
 .tree {
-	.col1 .changelink { float: left; line-height: 16px !important; margin: 6px 0 0 15px !important; }
+
+    .col1 .changelink {
+        float: left;
+        line-height: 16px !important;
+        margin: 6px 0 0 15px !important;
+    }
 }
 
 // cms language buttons
 #page_form_lang_tabs input {
-	@include border-bottom-radius(0); @include box-shadow(none !important);
-	background: #ccc !important; color: $font-color-medium !important; font-weight: normal !important;
-	border: none !important; margin: 0;
-	&:hover, &:focus { color: black !important; }
-	&.selected { background: white !important; color: black !important; }
-	&.notfilled { background: $background-color-light !important; color: #bbb !important; }
-}
-#lang_tab_content h2.header { background: $button-blue-light-color !important; @include border-top-right-radius();
-	margin-bottom: -3px !important; position: relative; }
+    @include border-bottom-radius(0);
+    @include box-shadow(none !important);
+    background: #ccc !important;
+    color: $font-color-medium !important;
+    font-weight: normal !important;
+    border: none !important;
+    margin: 0;
 
+    &:hover,
+	&:focus {
+        color: black !important;
+    }
+
+	&.selected {
+        background: white !important;
+        color: black !important;
+    }
+
+	&.notfilled {
+        background: $background-color-light !important;
+        color: #bbb !important;
+    }
+}
+
+#lang_tab_content h2.header {
+    background: $button-blue-light-color !important;
+    @include border-top-right-radius;
+    margin-bottom: -3px !important;
+    position: relative;
+}
 
 // nani/hvad language buttons
 .nani-language-tabs {
-	border-bottom: 5px solid $button-blue-light-color; margin-bottom: -3px; position: relative;
-	> span {
-		@include inline-block(); border: none !important; top: 0 !important; color: $font-color-medium !important;
-		font-weight: normal !important; vertical-align: top; background: white; padding: 8px 10px !important;
-		margin: 0 !important; @include border-top-radius();
-		a {
-			color: $font-color-medium !important; padding: 5px 10px;
-			&:hover, &:focus { color: black !important; text-decoration: none; }
-		}
-		.deletelink { display: inline; padding: 0 0 0 12px !important; margin: 0; @include border-top-radius(0);
-			background: url('../img/icon_deletelink.png') 0 .25em no-repeat !important; bottom: 0px !important;
-			right: -3px !important; }
-	}
-	> .empty { opacity: 1 !important; background: $background-color-light; color: $font-color-light; }
-	> .current { background: $button-blue-light-color; color: white !important; padding-left: 20px !important;
-		padding-right: 20px !important; @include text-shadow(0 1px 1px rgba(0,0,0,0.2)); }
-	> .current .deletelink { right: -12px !important; }
-}
-.inline-group .nani-language-tabs {
-	margin-bottom: 0;
-	> span { padding: 4px 10px !important; }
-	> .current { padding-left: 20px !important; padding-right: 20px !important; }
-	> .available { background: #eee; }
+    border-bottom: 5px solid $button-blue-light-color;
+    margin-bottom: -3px;
+    position: relative;
+
+    > span {
+        @include inline-block;
+        border: none !important;
+        top: 0 !important;
+        color: $font-color-medium !important;
+        font-weight: normal !important;
+        vertical-align: top;
+        background: white;
+        padding: 8px 10px !important;
+        margin: 0 !important;
+        @include border-top-radius;
+
+        a {
+            color: $font-color-medium !important;
+            padding: 5px 10px;
+
+            &:hover,
+			&:focus {
+                color: black !important;
+                text-decoration: none;
+            }
+        }
+
+        .deletelink {
+            display: inline;
+            padding: 0 0 0 12px !important;
+            margin: 0;
+            @include border-top-radius(0);
+            background: url("../img/icon_deletelink.png") 0 0.25em no-repeat !important;
+            bottom: 0px !important;
+            right: -3px !important;
+        }
+    }
+
+    > .empty {
+        opacity: 1 !important;
+        background: $background-color-light;
+        color: $font-color-light;
+    }
+
+    > .current {
+        background: $button-blue-light-color;
+        color: white !important;
+        padding-left: 20px !important;
+        padding-right: 20px !important;
+        @include text-shadow(0 1px 1px rgba(0, 0, 0, 0.2));
+    }
+
+    > .current .deletelink {
+        right: -12px !important;
+    }
 }
 
+.inline-group .nani-language-tabs {
+    margin-bottom: 0;
+
+    > span {
+        padding: 4px 10px !important;
+    }
+
+    > .current {
+        padding-left: 20px !important;
+        padding-right: 20px !important;
+    }
+
+    > .available {
+        background: #eee;
+    }
+}

--- a/djangocms_admin_style/sass/partials/_filer.scss
+++ b/djangocms_admin_style/sass/partials/_filer.scss
@@ -1,9 +1,21 @@
 // filer
 .filebrowser {
-	#content { margin-top: 20px; }
+
+	#content {
+        margin-top: 20px;
+    }
+
 	h1.folder_header {
-		background-image: none !important; background: none; margin: 0;
-		.changelink { font-size: 16px; line-height: 30px; }
-	}
-	.module table td { line-height: 16px; }
+        background-image: none !important;
+        background: none;
+        margin: 0;
+        .changelink {
+            font-size: 16px;
+            line-height: 30px;
+        }
+    }
+
+	.module table td {
+        line-height: 16px;
+    }
 }

--- a/djangocms_admin_style/sass/partials/_forms.scss
+++ b/djangocms_admin_style/sass/partials/_forms.scss
@@ -1,104 +1,289 @@
 form {
-	button, input, select, textarea { margin: 2px 0; font-size: 13px; }
-	small { color: $font-color-light; }
-	hr { margin: 5px 0; }
-	fieldset { vertical-align: middle; line-height: 2em; }
-	fieldset.collapsed h2 { background-image: none; border-bottom: none; margin-bottom: 0; padding-bottom: 5px; }
-	label {
-		word-wrap: break-word; color: $font-color-light; line-height: 18px; display: inline-block; /*min-width: 160px;*/
-		&.required { font-weight: bold; }
-	}
-	// input
-	input, textarea { @include border-radius(); border: 1px solid $button-silver-dark-color;
-		color: $button-silver-font-color; padding: 6px 5px; outline: none; }
-	input[type="checkbox"], input[type="radio"] { border: 0; display: inline; width: auto; margin-right: 6px; }
-	input[type="file"] { @include border-radius(); border: 1px solid $button-silver-dark-color;
-		color: $button-silver-font-color; padding: 6px 5px; outline: none; }
-	select { font-weight: normal; }
-	small { margin-left: 15px; }
-	.form-controls {
-		text-align: right; margin: 15px 0 0 0;
-		p { margin-top: 6px; }
-	}
-	.input-list { display: inline-block; vertical-align: top; line-height: 20px; }
-	.extra {
-		.right { float: right; margin-right: 10px; }
-	}
-	//.aligned p.help { padding-left: 100px; }
-	//.aligned.wide p.help { padding-left: 55px; }
-	.form-row { border-bottom-color: $line-color-ultralight; }
-	.form-row:last-child { border-bottom-color: transparent; }
-}
-.form-row input, .form-row textarea { width: 250px; }
-.form-row .select2-container {min-width: 250px + 12px;} //standard input width + default input paddings
-.inline-group .form-row input, .inline-group .form-row textarea { width: auto; }
+    button,
+	input,
+	select,
+	textarea {
+        margin: 2px 0;
+        font-size: 13px;
+    }
 
+    small {
+        color: $font-color-light;
+    }
 
-input:valid, textarea:valid {}
-input:invalid, textarea:invalid {
-	@include border-radius();
+    hr {
+        margin: 5px 0;
+    }
+
+    fieldset {
+        vertical-align: middle;
+        line-height: 2em;
+    }
+
+    fieldset.collapsed h2 {
+        background-image: none;
+        border-bottom: none;
+        margin-bottom: 0;
+        padding-bottom: 5px;
+    }
+
+    label {
+        word-wrap: break-word;
+        color: $font-color-light;
+        line-height: 18px;
+        display: inline-block;
+        /*min-width: 160px;*/
+
+        &.required {
+            font-weight: bold;
+        }
+    }
+
+    // input
+    input,
+	textarea {
+        @include border-radius;
+        border: 1px solid $button-silver-dark-color;
+        color: $button-silver-font-color;
+        padding: 6px 5px;
+        outline: none;
+    }
+
+    input[type="checkbox"],
+	input[type="radio"] {
+        border: 0;
+        display: inline;
+        width: auto;
+        margin-right: 6px;
+    }
+
+    input[type="file"] {
+        @include border-radius;
+        border: 1px solid $button-silver-dark-color;
+        color: $button-silver-font-color;
+        padding: 6px 5px;
+        outline: none;
+    }
+
+    select {
+        font-weight: normal;
+    }
+
+    small {
+        margin-left: 15px;
+    }
+
+    .form-controls {
+        text-align: right;
+        margin: 15px 0 0 0;
+
+	    p {
+            margin-top: 6px;
+        }
+    }
+
+    .input-list {
+        display: inline-block;
+        vertical-align: top;
+        line-height: 20px;
+    }
+
+    .extra {
+
+	    .right {
+            float: right;
+            margin-right: 10px;
+        }
+    }
+
+    //.aligned p.help { padding-left: 100px; }
+    //.aligned.wide p.help { padding-left: 55px; }
+    .form-row {
+        border-bottom-color: $line-color-ultralight;
+    }
+
+    .form-row:last-child {
+        border-bottom-color: transparent;
+    }
 }
+
+.form-row input,
+.form-row textarea {
+    width: 250px;
+}
+
+.form-row .select2-container {
+    min-width: 250px + 12px;
+}
+
+//standard input width + default input paddings
+.inline-group .form-row input,
+.inline-group .form-row textarea {
+    width: auto;
+
+}
+
+input:valid,
+textarea:valid {
+
+}
+
+input:invalid,
+textarea:invalid {
+    @include border-radius;
+}
+
 .no-boxshadow input:invalid,
-.no-boxshadow textarea:invalid { background-color: #f0dddd; }
+.no-boxshadow textarea:invalid {
+    background-color: #f0dddd;
+}
 
 // buttons
-button { @include button-common(); }
-input[type="submit"], input[type="button"] {
-	@include button-common(); padding: 8px 10px !important;
-	&.default { @include button-blue(); padding: 7px 10px !important; margin-top: 1px; }
+button {
+    @include button-common;
 }
+
+input[type="submit"],
+input[type="button"] {
+    @include button-common;
+    padding: 8px 10px !important;
+
+	&.default {
+        @include button-blue;
+        padding: 7px 10px !important;
+        margin-top: 1px;
+    }
+}
+
 a.button {
-	text-decoration: none; cursor: pointer; @include button-common();
-	&.tab { @include border-radius(0); }
+    text-decoration: none;
+    cursor: pointer;
+    @include button-common;
+    &.tab {
+        @include border-radius(0);
+    }
 }
 
 // date time
 .form-row {
-	p.datetime { line-height: 36px; }
+
+    p.datetime {
+        line-height: 36px;
+    }
 }
 
 // calendar
 div.calendar {
-	table {
-		caption { @include background-image(linear-gradient($background-color-dark, $background-color-medium));
-			background-color: $background-color-dark; color: $font-color-white !important; margin: 0;
-			@include border-top-radius(); }
-		td { padding: 0; background: #f3f3f3; }
-		td a { padding: 6px 4px; }
-	}
-	.today a { background: $info-color-ultralight; }
-}
-div.calendarbox {
-	width: 200px !important;
-	table th, table td { line-height: 12px; }
-	.calendarnav-previous, .calendarnav-next {
-		background: none; color: white; text-decoration: none; padding: 4px 7px 6px;
-		&:hover, &:focus { background: #666; }
-	}
-	.calendar-shortcuts { background: transparent; padding: 10px 0 6px 0; border-color: #ddd; }
-}
-div.calendarbox, div.clockbox {
-	@include border-radius(); background: #f3f3f3;
-	padding: 0; margin: 0; @include box-shadow(0 1px 10px rgba(0,0,0,0.1)); border: 1px solid #ccc;
-	caption, h2 { font-size: 14px; }
-	.calendar-cancel { @include border-bottom-radius(); background: none; margin-top: 5px !important;
-		padding: 5px 0 !important; }
-}
-// clock
-div.clockbox {
-	@include border-top-radius();
-	h2 { @include background-image(linear-gradient($background-color-dark, $background-color-medium));
-		background-color: $background-color-dark; color: $font-color-white !important;
-		@include border-top-radius(); }
-	.timelist a { padding: 5px 2px; }
-}
-.timelist a {
-	&, &:active, &:focus, &:hover { background: none !important; }
+
+    table {
+
+        caption {
+            @include background-image(linear-gradient($background-color-dark, $background-color-medium));
+            background-color: $background-color-dark;
+            color: $font-color-white !important;
+            margin: 0;
+            @include border-top-radius;
+        }
+
+        td {
+            padding: 0;
+            background: #f3f3f3;
+        }
+
+        td a {
+            padding: 6px 4px;
+        }
+    }
+
+    .today a {
+        background: $info-color-ultralight;
+    }
 }
 
-span.datetimeshortcuts a { color: $link-color; }
+div.calendarbox {
+    width: 200px !important;
+
+	table th,
+	table td {
+        line-height: 12px;
+    }
+
+    .calendarnav-previous,
+	.calendarnav-next {
+        background: none;
+        color: white;
+        text-decoration: none;
+        padding: 4px 7px 6px;
+
+		&:hover,
+		&:focus {
+            background: #666;
+        }
+    }
+
+    .calendar-shortcuts {
+        background: transparent;
+        padding: 10px 0 6px 0;
+        border-color: #ddd;
+    }
+}
+
+div.calendarbox,
+div.clockbox {
+    @include border-radius;
+    background: #f3f3f3;
+    padding: 0;
+    margin: 0;
+    @include box-shadow(0 1px 10px rgba(0, 0, 0, 0.1));
+    border: 1px solid #ccc;
+
+	caption, h2 {
+        font-size: 14px;
+    }
+
+	.calendar-cancel {
+        @include border-bottom-radius;
+        background: none;
+        margin-top: 5px !important;
+        padding: 5px 0 !important;
+    }
+}
+
+// clock
+div.clockbox {
+    @include border-top-radius;
+
+	h2 {
+        @include background-image(linear-gradient($background-color-dark, $background-color-medium));
+        background-color: $background-color-dark;
+        color: $font-color-white !important;
+        @include border-top-radius;
+    }
+
+    .timelist a {
+        padding: 5px 2px;
+    }
+}
+
+.timelist a {
+
+    &,
+	&:active,
+	&:focus,
+	&:hover {
+        background: none !important;
+    }
+}
+
+span.datetimeshortcuts a {
+    color: $link-color;
+}
 
 // filter horizontal
 .selector {
-	.selector-chooseall, .selector-clearall { line-height: 14px; }
+
+    .selector-chooseall,
+	.selector-clearall {
+        line-height: 14px;
+    }
 }

--- a/djangocms_admin_style/sass/partials/_icons.scss
+++ b/djangocms_admin_style/sass/partials/_icons.scss
@@ -1,32 +1,89 @@
-
-.addlink, .changelink, .deletelink { padding-left: 15px; }
-
-.deletelink { background-image: url('../img/icon_deletelink.png'); }
-
-.related-lookup, .add-another {
-	margin: 0 5px;
-	&:hover, &:focus, &:active { text-decoration: none !important; }
+.addlink,
+.changelink,
+.deletelink {
+    padding-left: 15px;
 }
-.add-another { @include hide-text(); @include inline-block(); width: 14px; height: 14px;
-	background: url('../img/icon_addlink_large.gif') 0 0 no-repeat; }
 
-.tree .changelink { background-image: url('../img/icon_changelink_white.png'); }
+.deletelink {
+    background-image: url("../img/icon_deletelink.png");
+}
 
-#sitemap li .col-softroot span.icon { background: url('../img/icon_softroot.png') 0 0 no-repeat;
-	width: 15px; height: 15px; margin: 7px 5px 0 0; }
+.related-lookup,
+.add-another {
+    margin: 0 5px;
+
+    &:hover,
+	&:focus,
+	&:active {
+        text-decoration: none !important;
+    }
+}
+
+.add-another {
+    @include hide-text;
+    @include inline-block;
+    width: 14px;
+    height: 14px;
+    background: url("../img/icon_addlink_large.gif") 0 0 no-repeat;
+}
+
+.tree .changelink {
+    background-image: url("../img/icon_changelink_white.png");
+}
+
+#sitemap li .col-softroot span.icon {
+    background: url("../img/icon_softroot.png") 0 0 no-repeat;
+    width: 15px;
+    height: 15px;
+    margin: 7px 5px 0 0;
+}
 
 // retina
-@media only screen and (-webkit-min-device-pixel-ratio:2),
-only screen and (-o-min-device-pixel-ratio:2),
-only screen and (min--moz-device-pixel-ratio:2),
-only screen and (min-device-pixel-ratio:2) {
-	.addlink { background-image: url('../img/icon_addlink@2x.gif'); background-size: 11px; }
-	.changelink { background-image: url('../img/icon_changelink@2x.gif'); background-size: 11px; }
-	.tree .changelink { background-image: url('../img/icon_changelink_white@2x.png'); background-size: 11px; }
-	.deletelink { background-image: url('../img/icon_deletelink@2x.png'); background-size: 11px; }
-	#sitemap li .col-softroot span.icon { background-image: url('../img/icon_softroot@2x.png'); background-size: 15px; }
-	.related-lookup { @include hide-text(); @include inline-block(); width: 16px; height: 16px;
-		background: url('../img/icon_searchbox@2x.png') 0 0 no-repeat; background-size: 16px; }
-	.add-another { @include hide-text(); @include inline-block(); width: 14px; height: 14px;
-		background: url('../img/icon_addlink_large@2x.gif') 0 0 no-repeat; background-size: 14px; }
+@media only screen and (-webkit-min-device-pixel-ratio: 2),
+only screen and (-o-min-device-pixel-ratio: 2),
+only screen and (min--moz-device-pixel-ratio: 2),
+only screen and (min-device-pixel-ratio: 2) {
+
+    .addlink {
+        background-image: url("../img/icon_addlink@2x.gif");
+        background-size: 11px;
+    }
+
+    .changelink {
+        background-image: url("../img/icon_changelink@2x.gif");
+        background-size: 11px;
+    }
+
+    .tree .changelink {
+        background-image: url("../img/icon_changelink_white@2x.png");
+        background-size: 11px;
+    }
+
+    .deletelink {
+        background-image: url("../img/icon_deletelink@2x.png");
+        background-size: 11px;
+    }
+
+    #sitemap li .col-softroot span.icon {
+        background-image: url("../img/icon_softroot@2x.png");
+        background-size: 15px;
+    }
+
+    .related-lookup {
+        @include hide-text;
+        @include inline-block;
+        width: 16px;
+        height: 16px;
+        background: url("../img/icon_searchbox@2x.png") 0 0 no-repeat;
+        background-size: 16px;
+    }
+
+    .add-another {
+        @include hide-text;
+        @include inline-block;
+        width: 14px;
+        height: 14px;
+        background: url("../img/icon_addlink_large@2x.gif") 0 0 no-repeat;
+        background-size: 14px;
+    }
 }

--- a/djangocms_admin_style/sass/partials/_iconsOLD.scss
+++ b/djangocms_admin_style/sass/partials/_iconsOLD.scss
@@ -11,15 +11,14 @@ a.active.selector-chooseall,
 .selector-add,
 .inline-group .add-row a,
 a[id^="calendarlink"],
-a[id^="clocklink"]
-{
-	background: none !important;
-	padding-left: 10px;
-	line-height: 10px;
+a[id^="clocklink"] {
+    background: none !important;
+    padding-left: 10px;
+    line-height: 10px;
+
 	&:hover {
-		text-decoration: none !important;
-	}
-	
+        text-decoration: none !important;
+    }
 }
 
 .addlink:before,
@@ -35,58 +34,131 @@ a.active.selector-chooseall:before,
 .inline-group .add-row a:before,
 .add-another:before,
 a[id^="calendarlink"]:before,
-a[id^="clocklink"]:before
-{
-	font-family: 'django-admin-icons';
-	font-style: normal;
-	speak: none;
-	font-weight: normal;
-	font-size: 75%;
-	-webkit-font-smoothing: antialiased;
-	padding-right: 5px;
+a[id^="clocklink"]:before {
+    font-family: 'django-admin-icons';
+    font-style: normal;
+    speak: none;
+    font-weight: normal;
+    font-size: 75%;
+    -webkit-font-smoothing: antialiased;
+    padding-right: 5px;
 }
 
+.addlink:before {
+    content: "\22";
+}
 
-.addlink:before { content: "\22";  }
-.changelink:before { content: "\21"; }
-#changelist-search label:before { content: "\23"; }
-.deletelink:before { content: "\24"; }
-.selector-remove:before, a.selector-clearall:before, a.active.selector-clearall:before { content: "\25"; font-size: 100%; }
-.selector-add:before, a.selector-chooseall:before, a.active.selector-chooseall:before { content: "\26"; font-size: 100%; }
-.inline-group .add-row a:before { content: "\22";  }
-.add-another:before { content: "\22";  }
-a[id^="calendarlink"]:before { content: "\2c";  }
-a[id^="clocklink"]:before { content: "\2d"; }
+.changelink:before {
+    content: "\21";
+}
+
+#changelist-search label:before {
+    content: "\23";
+}
+
+.deletelink:before {
+    content: "\24";
+}
+
+.selector-remove:before, a.selector-clearall:before,
+a.active.selector-clearall:before {
+    content: "\25";
+    font-size: 100%;
+}
+
+.selector-add:before,
+a.selector-chooseall:before,
+a.active.selector-chooseall:before {
+    content: "\26";
+    font-size: 100%;
+}
+
+.inline-group .add-row a:before {
+    content: "\22";
+}
+
+.add-another:before {
+    content: "\22";
+}
+
+a[id^="calendarlink"]:before {
+    content: "\2c";
+}
+
+a[id^="clocklink"]:before {
+    content: "\2d";
+}
 
 .actionlist {
-	.addlink, .changelink { padding-left: 0; }
+
+	.addlink, .changelink {
+        padding-left: 0;
+    }
 }
 
-#changelist-search label { font-weight: bold; }
-#changelist-search label img { display: none;}
-.help-tooltip { display: none; }
-a.active.selector-chooseall {  }
-.selector-remove, .selector-add { display: inline !important; font-size: 125% !important; padding-left: 1px; color: $font-color-white !important; }
-.selector-remove:before, .selector-add:before { color: $font-color; }
-.inline-group .add-row a { color: $success-color !important; padding-left: 5px !important; }
+#changelist-search label {
+    font-weight: bold;
+}
 
-.add-another { 
-	margin-left: 10px; 
-	&:hover, &:link:hover {
-		text-decoration: none;
+#changelist-search label img {
+    display: none;
+}
+
+.help-tooltip {
+    display: none;
+}
+
+a.active.selector-chooseall {
+
+}
+
+.selector-remove,
+.selector-add {
+    display: inline !important;
+    font-size: 125% !important;
+    padding-left: 1px;
+    color: $font-color-white !important;
+}
+
+.selector-remove:before,
+.selector-add:before {
+    color: $font-color;
+}
+
+.inline-group .add-row a {
+    color: $success-color !important;
+    padding-left: 5px !important;
+}
+
+.add-another {
+    margin-left: 10px;
+
+	&:hover,
+	&:link:hover {
+        text-decoration: none;
+    }
+}
+
+.add-another img {
+    display: none;
+}
+
+a[id^="calendarlink"],
+a[id^="clocklink"] {
+    display: inline-block;
+    font-size: 19px;
+    height: 19px;
+    width: 19px;
+    padding-left: 0 !important;
+
+	img {
+		display: none;
 	}
 }
-.add-another img { display: none; }
-
-
-a[id^="calendarlink"], a[id^="clocklink"] {
-	display: inline-block;
-	font-size: 19px;
-	height: 19px;
-	width: 19px;
-	padding-left: 0 !important; 
-}
-a[id^="calendarlink"] img, , a[id^="clocklink"] img { display: none;}
 
 /* Sepcials */
-.selector ul.selector-chooser { @include border-radius(10px); background: $background-color-light !important; height: 44px !important; }
+.selector ul.selector-chooser {
+    @include border-radius(10px);
+    background: $background-color-light !important;
+    height: 44px !important;
+}

--- a/djangocms_admin_style/sass/partials/_messages.scss
+++ b/djangocms_admin_style/sass/partials/_messages.scss
@@ -1,264 +1,322 @@
 /* Statuses Mixins */
 
 @mixin message-info {
-	@include background-image(linear-gradient( $info-color-light, $info-color 80%, $info-color-dark));
+    @include background-image(linear-gradient($info-color-light, $info-color 80%, $info-color-dark));
+
 	.close {
-		@include box-shadow($info-color 0 0 2px inset);
-		background: $info-color;
-		border: 1px solid $info-color;
-		&:hover{
-			@include background-image(linear-gradient( $info-color-light, $info-color-dark)); 
-			@include box-shadow(none);
-			border: 1px solid $info-color;
-		}	
-	}
+        @include box-shadow($info-color 0 0 2px inset);
+        background: $info-color;
+        border: 1px solid $info-color;
+
+		&:hover {
+            @include background-image(linear-gradient($info-color-light, $info-color-dark));
+            @include box-shadow(none);
+            border: 1px solid $info-color;
+        }
+    }
 }
+
 @mixin message-success {
-	@include background-image(linear-gradient( $success-color-light, $success-color 80%, $success-color-dark));
+    @include background-image(linear-gradient($success-color-light, $success-color 80%, $success-color-dark));
+
 	.close {
-		@include box-shadow($success-color 0 0 2px inset);
-		background: $success-color;
-		border: 1px solid $success-color;
-		&:hover{
-			@include background-image(linear-gradient( $success-color-light, $success-color-dark)); 
-			@include box-shadow(none);
-			border: 1px solid $success-color;
-		}	
-	}
+        @include box-shadow($success-color 0 0 2px inset);
+        background: $success-color;
+        border: 1px solid $success-color;
+
+		&:hover {
+            @include background-image(linear-gradient($success-color-light, $success-color-dark));
+            @include box-shadow(none);
+            border: 1px solid $success-color;
+        }
+    }
 }
+
 @mixin message-warning {
-	@include background-image(linear-gradient( $warning-color-light, $warning-color 80%, $warning-color-dark));
+    @include background-image(linear-gradient($warning-color-light, $warning-color 80%, $warning-color-dark));
+
 	.close {
-		@include box-shadow($warning-color 0 0 2px inset);
-		background: $warning-color;
-		border: 1px solid $warning-color;
-		&:hover{
-			@include background-image(linear-gradient( $warning-color-light, $warning-color-dark)); 
-			@include box-shadow(none);
-			border: 1px solid $warning-color;
-		}	
-	}
+        @include box-shadow($warning-color 0 0 2px inset);
+        background: $warning-color;
+        border: 1px solid $warning-color;
+
+		&:hover {
+            @include background-image(linear-gradient($warning-color-light, $warning-color-dark));
+            @include box-shadow(none);
+            border: 1px solid $warning-color;
+        }
+    }
 }
 
 @mixin message-error {
-	@include background-image(linear-gradient( $error-color-light, $error-color 80%, $error-color-dark));
+    @include background-image(linear-gradient($error-color-light, $error-color 80%, $error-color-dark));
+
 	.close {
-		@include box-shadow($error-color 0 0 2px inset);
-		background: $error-color;
-		border: 1px solid $error-color;
-		&:hover{
-			@include background-image(linear-gradient( $error-color-light, $error-color-dark)); 
-			@include box-shadow(none);
-			border: 1px solid $error-color;
-		}	
-	}
+        @include box-shadow($error-color 0 0 2px inset);
+        background: $error-color;
+        border: 1px solid $error-color;
+
+		&:hover {
+            @include background-image(linear-gradient($error-color-light, $error-color-dark));
+            @include box-shadow(none);
+            border: 1px solid $error-color;
+        }
+    }
 }
 
-@mixin stripes($stripe-opacity){
-	@include background-size (60px 60px);
-	@include background-image(linear-gradient(-45deg, rgba(255, 255, 255, $stripe-opacity) 25%, rgba(255, 255, 255, 0) 25%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, $stripe-opacity) 50%, rgba(255, 255, 255, $stripe-opacity) 75%, rgba(255, 255, 255, 0) 75%, rgba(255, 255, 255, 0)));			
+@mixin stripes($stripe-opacity) {
+    @include background-size(60px 60px);
+    @include background-image(
+		linear-gradient(-45deg,
+			rgba(255, 255, 255, $stripe-opacity) 25%,
+			rgba(255, 255, 255, 0) 25%,
+			rgba(255, 255, 255, 0) 50%,
+			rgba(255, 255, 255, $stripe-opacity) 50%,
+			rgba(255, 255, 255, $stripe-opacity) 75%,
+			rgba(255, 255, 255, 0) 75%,
+			rgba(255, 255, 255, 0)
+		)
+	);
 }
 
 /* Messages */
 .messages {
-	color: #fff;
-	font-weight: bold;
-	font-size: 125%;
-	text-align: center;
-	position: fixed;
-	width: 100%;
-	z-index: 1000;
-		
+    color: #fff;
+    font-weight: bold;
+    font-size: 125%;
+    text-align: center;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+
 	ul {
-		list-style: none;
-		margin: 0;
-		padding: 0;
-		//border-bottom: 1px solid $line-color-medium;
-	}
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        //border-bottom: 1px solid $line-color-medium;
+
+    }
+
 	li {
-		line-height: 2.9;	
-	}
+        line-height: 2.9;
+    }
+
 	.close {
-		@include border-radius(10px);
-		display: block;
-		cursor: pointer;
-		color: #fff;
-		height: 20px; 
-		line-height: 2.5;
-		margin-right: 20px; 
-		margin-top: 12px;
-		font-size: 10px;
-		vertical-align: middle; 
-		width: 20px; 
+        @include border-radius(10px);
+        display: block;
+        cursor: pointer;
+        color: #fff;
+        height: 20px;
+        line-height: 2.5;
+        margin-right: 20px;
+        margin-top: 12px;
+        font-size: 10px;
+        vertical-align: middle;
+        width: 20px;
+
 		&:hover {
-			text-decoration: none;
-		}
+            text-decoration: none;
+        }
+
 		span {
-			display: block;
-			margin-top: -2px;
-			margin-left: 1px;
-		}
-	}
-	
+            display: block;
+            margin-top: -2px;
+            margin-left: 1px;
+        }
+    }
+
 	.info {
-		@include message-info;
-	}
+        @include message-info;
+    }
+
 	.success {
-		@include message-success;		
-	}
+        @include message-success;
+    }
+
 	.warning {
-		@include message-warning;
-	}
+        @include message-warning;
+    }
+
 	.error {
-		@include message-error;
-	}	
+        @include message-error;
+    }
 }
 
 .inline-messages {
-	color: #fff;
-	font-size: 100%;
-	text-align: left;
-	position: relative;
+    color: #fff;
+    font-size: 100%;
+    text-align: left;
+    position: relative;
+
 	.inline-message {
-		@include border-radius();
-		font-weight: bold;
-		padding: 5px 10px;			
-	}
+        @include border-radius;
+        font-weight: bold;
+        padding: 5px 10px;
+    }
+
 	.animate {
-		@include stripes(0.1);
-	}	
+        @include stripes(0.1);
+    }
+
 	.inline-info {
-		background-color: $info-color;
-		border: 1px solid $info-color-dark;
-	}
+        background-color: $info-color;
+        border: 1px solid $info-color-dark;
+    }
+
 	.inline-success {
-		@include message-success;	
-		border: 1px solid $success-color-dark;
-	}
+        @include message-success;
+        border: 1px solid $success-color-dark;
+    }
+
 	.inline-warning {
-		@include message-warning;
-		border: 1px solid $warning-color-dark;
-	}
+        @include message-warning;
+        border: 1px solid $warning-color-dark;
+    }
+
 	.inline-error {
-		@include message-error;
-		border: 1px solid $error-color-dark;
-	}	
+        @include message-error;
+        border: 1px solid $error-color-dark;
+    }
 }
 
 header {
+
 	&.header-info {
-		@include message-info;	
-		.meta small {
-			color: #fff;
-		}
-		nav li.internal {
-			@include box-shadow(0 0 0 0);
-		}
-	}
+        @include message-info;
+
+	    .meta small {
+            color: #fff;
+        }
+
+	    nav li.internal {
+            @include box-shadow(0 0 0 0);
+        }
+    }
+
 	&.header-success {
-		@include message-success;	
-		.meta small {
-			color: #fff;
-		}
-		nav li.internal {
-			@include box-shadow(0 0 0 0);
-		}
-	}
+        @include message-success;
+
+	    .meta small {
+            color: #fff;
+        }
+
+	    nav li.internal {
+            @include box-shadow(0 0 0 0);
+        }
+    }
+
 	&.header-warning {
-		@include message-warning;
-		.meta small {
-			color: #fff;
-		}
-		nav li.internal {
-			@include box-shadow(0 0 0 0);
-		}
-	}
+        @include message-warning;
+
+	    .meta small {
+            color: #fff;
+        }
+
+	    nav li.internal {
+            @include box-shadow(0 0 0 0);
+        }
+    }
+
 	&.header-error {
-		@include message-error;
-		.meta small {
-			color: #fff;
-		}
-		nav li.internal {
-			@include box-shadow(0 0 0 0);
-		}
-	}
+        @include message-error;
+
+	    .meta small {
+            color: #fff;
+        }
+
+	    nav li.internal {
+            @include box-shadow(0 0 0 0);
+        }
+    }
 }
 
 .hint {
-	@include border-radius();
-	border-top: 1px solid $line-color-white;
-	margin-bottom: 15px; 
-	padding: 15px 20px;
-	&.hint-info{
-		@include box-shadow($info-color-light 0 1px 1px 0px);
-		background-color: $background-color-highlighter;
-		color: $info-color;
-		text-align: center;
+    @include border-radius;
+    border-top: 1px solid $line-color-white;
+    margin-bottom: 15px;
+    padding: 15px 20px;
+
+	&.hint-info {
+        @include box-shadow($info-color-light 0 1px 1px 0px);
+        background-color: $background-color-highlighter;
+        color: $info-color;
+        text-align: center;
+
 		h1, h2, h3, h4, h5, h6 {
-			margin: 5px 0;
-			color: $info-color;
-		}
+            margin: 5px 0;
+            color: $info-color;
+        }
+
 		p {
-			margin-top: 5px;
-		}
+            margin-top: 5px;
+        }
+
 		a {
-			text-decoration: underline;
-			&:hover {
-				color: $info-color-dark;
-			}
-		}
+            text-decoration: underline;
+
+		    &:hover {
+                color: $info-color-dark;
+            }
+        }
+
 		.close {
-			background: url(../img/sprite.png) no-repeat 0 -100px;
-			display: inline-block; 
-			height: 16px; 
-			width: 16px;
-		}
-	}
-	&.hint-success {
-		@include box-shadow($success-color-light 0 1px 1px 0px);
-		background-color: $success-color-ultralight;
-		color: $success-color;
-		font-size: 120%;
+            background: url(../img/sprite.png) no-repeat 0 -100px;
+            display: inline-block;
+            height: 16px;
+            width: 16px;
+        }
+    }
+    &.hint-success {
+        @include box-shadow($success-color-light 0 1px 1px 0px);
+        background-color: $success-color-ultralight;
+        color: $success-color;
+        font-size: 120%;
+
 		.icon {
-			margin-right: 10px;
-		}
+            margin-right: 10px;
+        }
+
 		span {
-			display: inline-block;
-		}
-	}	
-	&.hint-warning {
-		@include box-shadow($warning-color-light 0 1px 1px 0px);
-		background-color: $warning-color-ultralight;
-		color: $warning-color;
-		font-size: 120%;
+            display: inline-block;
+        }
+    }
+    &.hint-warning {
+        @include box-shadow($warning-color-light 0 1px 1px 0px);
+        background-color: $warning-color-ultralight;
+        color: $warning-color;
+        font-size: 120%;
+
 		.icon {
-			margin-right: 10px;
-		}
+            margin-right: 10px;
+        }
+
 		span {
-			display: inline-block;
-		}
+            display: inline-block;
+        }
+
 		.button {
-			margin-top: -5px;
-		}
-	}	
-	&.hint-error {
-		@include box-shadow($error-color-light 0 1px 1px 0px);
-		background-color: $error-color-ultralight;
-		color: $error-color;
-		font-size: 120%;
+            margin-top: -5px;
+        }
+    }
+    &.hint-error {
+        @include box-shadow($error-color-light 0 1px 1px 0px);
+        background-color: $error-color-ultralight;
+        color: $error-color;
+        font-size: 120%;
+
 		.icon {
-			margin-right: 10px;
-		}
+            margin-right: 10px;
+        }
+
 		span {
-			display: inline-block;
-		}
+            display: inline-block;
+        }
+
 		.button {
-			margin-top: -5px;
-			&.small {
-				margin-top: -2px;
-			}
-		}
-	}	
-	
-	
+            margin-top: -5px;
+            &.small {
+                margin-top: -2px;
+            }
+        }
+    }
 }

--- a/djangocms_admin_style/sass/partials/_mixins.scss
+++ b/djangocms_admin_style/sass/partials/_mixins.scss
@@ -1,172 +1,219 @@
 // mixins
 
-@mixin box(){
-	@include border-radius(); @include box-shadow(0 1px 2px 1px rgba(0,0,0,0.08)); padding: 0;
-	background: $background-color-white; border: none; margin-bottom: 5px;
-	h2, h3, h4, h5, h6 { margin-bottom: 12px; margin-top: 0; }
+@mixin box {
+    @include border-radius;
+    @include box-shadow(0 1px 2px 1px rgba(0, 0, 0, 0.08));
+    padding: 0;
+    background: $background-color-white;
+    border: none;
+    margin-bottom: 5px;
+
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        margin-bottom: 12px;
+        margin-top: 0;
+    }
 }
 
-@mixin stripes($stripe-opacity){
-	@include background-size(100% 400%);
-	@include background-image(linear-gradient(-45deg, rgba(255, 255, 255, $stripe-opacity) 25%, rgba(255, 255, 255, 0) 25%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, $stripe-opacity) 50%, rgba(255, 255, 255, $stripe-opacity) 75%, rgba(255, 255, 255, 0) 75%, rgba(255, 255, 255, 0)));
+@mixin stripes($stripe-opacity) {
+    @include background-size(100% 400%);
+    @include background-image(linear-gradient(-45deg, rgba(255, 255, 255, $stripe-opacity) 25%, rgba(255, 255, 255, 0) 25%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, $stripe-opacity) 50%, rgba(255, 255, 255, $stripe-opacity) 75%, rgba(255, 255, 255, 0) 75%, rgba(255, 255, 255, 0)));
 }
 
 @mixin button-common-init {
-	@include background-image(linear-gradient($button-silver-light-color, $button-silver-medium-color) !important);
-	@include box-shadow($button-silver-medium-color 0 0 $button-shadow-width inset !important);
-	background-color: $button-silver-light-color !important;
-	border: 1px solid $button-silver-medium-color !important;
-	border-bottom: 1px solid $button-silver-dark-color !important;
-	&:hover { background: $button-silver-light-color !important; }
+    @include background-image(linear-gradient($button-silver-light-color, $button-silver-medium-color) !important);
+    @include box-shadow($button-silver-medium-color 0 0 $button-shadow-width inset !important);
+    background-color: $button-silver-light-color !important;
+    border: 1px solid $button-silver-medium-color !important;
+    border-bottom: 1px solid $button-silver-dark-color !important;
+
+    &:hover {
+        background: $button-silver-light-color !important;
+    }
 }
 
-@mixin button-common() {
-	@include border-radius();
-	@include button-common-init();
-	color: $button-silver-font-color !important;
-	font-weight: bolder !important;
-	font-size: 12px !important;
-	line-height: 15px !important;
-	overflow: visible;
-	padding: 5px 10px 5px !important;
-	text-decoration: none !important;
-	width: auto;
-	&.small {
-		padding: 3px 8px 4px !important;
-	}
-	&:hover, &:active, &.select, &:visited {
-		background: $button-silver-light-color;
-		color: $button-silver-font-color;
-		text-decoration: none;
-	}
-	&.animate {
-		@include stripes(.2);
-	}
+@mixin button-common {
+    @include border-radius;
+    @include button-common-init;
+    color: $button-silver-font-color !important;
+    font-weight: bolder !important;
+    font-size: 12px !important;
+    line-height: 15px !important;
+    overflow: visible;
+    padding: 5px 10px 5px !important;
+    text-decoration: none !important;
+    width: auto;
+
+    &.small {
+        padding: 3px 8px 4px !important;
+    }
+
+    &:hover,
+    &:active,
+    &.select,
+    &:visited {
+        background: $button-silver-light-color;
+        color: $button-silver-font-color;
+        text-decoration: none;
+    }
+
+    &.animate {
+        @include stripes(0.2);
+    }
 }
 
 @mixin button-blue {
-	&, &:visited {
-		@include background-image(linear-gradient($button-blue-light-color, $button-blue-medium-color) !important); }
-	@include box-shadow($button-blue-light-color 0 0 $button-shadow-width inset !important);
-	background-color: $button-blue-medium-color !important;
-	background-image: none !important;
-	border: 1px solid $button-blue-light-color !important;
-	border-bottom: 1px solid $button-blue-dark-color !important;
-	color: $button-blue-font-color !important;
-	&:hover, &:focus {
-		background: $button-blue-light-color !important;
-		color: $button-blue-font-color !important;
-	}
-	&:active {
-		background: $button-blue-medium-color !important;
-	}
-	&.animate {
-		@include stripes(.1);
-	}
+
+    &,
+    &:visited {
+        @include background-image(linear-gradient($button-blue-light-color, $button-blue-medium-color) !important);
+    }
+
+    @include box-shadow($button-blue-light-color 0 0 $button-shadow-width inset !important);
+    background-color: $button-blue-medium-color !important;
+    background-image: none !important;
+    border: 1px solid $button-blue-light-color !important;
+    border-bottom: 1px solid $button-blue-dark-color !important;
+    color: $button-blue-font-color !important;
+
+    &:hover,
+    &:focus {
+        background: $button-blue-light-color !important;
+        color: $button-blue-font-color !important;
+    }
+
+    &:active {
+        background: $button-blue-medium-color !important;
+    }
+
+    &.animate {
+        @include stripes(0.1);
+    }
 }
 
 @mixin button-green {
-	&, &:visited {
-		@include background-image(linear-gradient($button-green-light-color, $button-green-medium-color) !important); }
-	@include box-shadow($button-green-light-color 0 0 $button-shadow-width inset !important);
-	background-color: $button-green-medium-color !important;
-	border: 1px solid $button-green-light-color !important;
-	border-bottom: 1px solid $button-green-dark-color !important;
-	color: $button-green-font-color !important;
-	&:hover {
-		background: $button-green-light-color  !important;
-		color: $button-green-font-color  !important;
-	}
-	&:active {
-		background: $button-green-medium-color  !important;
-	}
-	&.animate {
-		@include stripes(.1);
-	}
+    &,
+    &:visited {
+        @include background-image(linear-gradient($button-green-light-color, $button-green-medium-color) !important);
+    }
+
+    @include box-shadow($button-green-light-color 0 0 $button-shadow-width inset !important);
+    background-color: $button-green-medium-color !important;
+    border: 1px solid $button-green-light-color !important;
+    border-bottom: 1px solid $button-green-dark-color !important;
+    color: $button-green-font-color !important;
+
+    &:hover {
+        background: $button-green-light-color !important;
+        color: $button-green-font-color !important;
+    }
+
+    &:active {
+        background: $button-green-medium-color !important;
+    }
+
+    &.animate {
+        @include stripes(0.1);
+    }
 }
 
 @mixin button-orange {
-	@include background-image(linear-gradient($button-orange-light-color, $button-orange-medium-color));
-	@include box-shadow($button-orange-light-color 0 0 $button-shadow-width inset);
-	background-color: $button-orange-medium-color !important;
-	border: 1px solid $button-orange-light-color !important;
-	border-bottom: 1px solid $button-orange-dark-color !important;
-	color: $button-orange-font-color !important;
-	&:hover {
-		background: $button-orange-light-color;
-		color: $button-orange-font-color;
-	}
-	&:active {
-		background: $button-orange-medium-color;
-	}
-	&.animate {
-		@include stripes(.2);
-	}
+    @include background-image(linear-gradient($button-orange-light-color, $button-orange-medium-color));
+    @include box-shadow($button-orange-light-color 0 0 $button-shadow-width inset);
+    background-color: $button-orange-medium-color !important;
+    border: 1px solid $button-orange-light-color !important;
+    border-bottom: 1px solid $button-orange-dark-color !important;
+    color: $button-orange-font-color !important;
+
+    &:hover {
+        background: $button-orange-light-color;
+        color: $button-orange-font-color;
+    }
+
+    &:active {
+        background: $button-orange-medium-color;
+    }
+
+    &.animate {
+        @include stripes(0.2);
+    }
 }
 
 @mixin button-red {
-	@include background-image(linear-gradient($button-red-light-color, $button-red-medium-color) !important);
-	@include box-shadow($button-red-light-color 0 0 $button-shadow-width inset !important);
-	background-color: $button-red-medium-color !important;
-	border: 1px solid $button-red-light-color !important;
-	border-bottom: 1px solid $button-red-dark-color !important;
-	color: $button-red-font-color !important;
+    @include background-image(linear-gradient($button-red-light-color, $button-red-medium-color) !important);
+    @include box-shadow($button-red-light-color 0 0 $button-shadow-width inset !important);
+    background-color: $button-red-medium-color !important;
+    border: 1px solid $button-red-light-color !important;
+    border-bottom: 1px solid $button-red-dark-color !important;
+    color: $button-red-font-color !important;
+
 	&:hover {
-		background: $button-red-light-color !important;
-		color: $button-red-font-color !important;
-	}
+        background: $button-red-light-color !important;
+        color: $button-red-font-color !important;
+    }
+
 	&:active {
-		background: $button-red-medium-color !important;
-	}
+        background: $button-red-medium-color !important;
+    }
+
 	&.animate {
-		@include stripes(.2);
-	}
+        @include stripes(0.2);
+    }
 }
 
 @mixin button-black {
-	@include background-image(linear-gradient($button-black-light-color, $button-black-medium-color));
-	@include box-shadow($button-black-light-color 0 0 $button-shadow-width inset);
-	background-color: $button-black-medium-color !important;
-	border: 1px solid $button-black-light-color;
-	border-bottom: 1px solid $button-black-dark-color;
-	color: $button-inactive-font-color !important;
-	cursor: default;
-	&:hover {
-		@include background-image(linear-gradient($button-black-light-color, $button-black-medium-color));
-		border-color: $button-black-medium-color;
-		color: $button-black-font-color;
+    @include background-image(linear-gradient($button-black-light-color, $button-black-medium-color));
+    @include box-shadow($button-black-light-color 0 0 $button-shadow-width inset);
+    background-color: $button-black-medium-color !important;
+    border: 1px solid $button-black-light-color;
+    border-bottom: 1px solid $button-black-dark-color;
+    color: $button-inactive-font-color !important;
+    cursor: default;
 
-	}
-	&:active, &.select {
-		@include background-image(linear-gradient($button-black-light-color, $button-black-medium-color));
-		border-color: $button-black-medium-color;
-		color: $button-black-font-color;
-	}
+	&:hover {
+        @include background-image(linear-gradient($button-black-light-color, $button-black-medium-color));
+        border-color: $button-black-medium-color;
+        color: $button-black-font-color;
+    }
+
+	&:active,
+	&.select {
+        @include background-image(linear-gradient($button-black-light-color, $button-black-medium-color));
+        border-color: $button-black-medium-color;
+        color: $button-black-font-color;
+    }
+
 	&.animate {
-		@include stripes(.1);
-	}
+        @include stripes(0.1);
+    }
 }
 
 @mixin button-inactive {
-	@include background-image(linear-gradient($button-inactive-light-color, $button-inactive-medium-color));
-	@include box-shadow($button-inactive-light-color 0 0 $button-shadow-width inset);
-	background-color: $button-inactive-medium-color !important;
-	border: 1px solid $button-inactive-light-color;
-	border-bottom: 1px solid $button-inactive-dark-color;
-	color: $button-inactive-font-color;
-	cursor: default;
-	&:hover {
-		@include background-image(linear-gradient($button-inactive-light-color, $button-inactive-medium-color));
-		border-color: $button-inactive-medium-color;
-		color: $button-inactive-font-color;
+    @include background-image(linear-gradient($button-inactive-light-color, $button-inactive-medium-color));
+    @include box-shadow($button-inactive-light-color 0 0 $button-shadow-width inset);
+    background-color: $button-inactive-medium-color !important;
+    border: 1px solid $button-inactive-light-color;
+    border-bottom: 1px solid $button-inactive-dark-color;
+    color: $button-inactive-font-color;
+    cursor: default;
 
-	}
-	&:active, &.select {
-		@include background-image(linear-gradient($button-inactive-light-color, $button-inactive-medium-color));
-		border-color: $button-inactive-medium-color;
-		color: $button-inactive-font-color;
-	}
+	&:hover {
+        @include background-image(linear-gradient($button-inactive-light-color, $button-inactive-medium-color));
+        border-color: $button-inactive-medium-color;
+        color: $button-inactive-font-color;
+    }
+
+    &:active,
+	&.select {
+        @include background-image(linear-gradient($button-inactive-light-color, $button-inactive-medium-color));
+        border-color: $button-inactive-medium-color;
+        color: $button-inactive-font-color;
+    }
+
 	&.animate {
-		@include stripes(.1);
-	}
+        @include stripes(0.1);
+    }
 }

--- a/djangocms_admin_style/sass/partials/_mobile.scss
+++ b/djangocms_admin_style/sass/partials/_mobile.scss
@@ -1,124 +1,323 @@
 // base
-html, body { height: auto; }
-#content { margin: 0 5px; }
-#container { margin: 0; min-width: 240px !important; }
-#branding { display: none; }
-.login #branding { display: block; }
-#user-tools { position: relative; text-align: center; }
+html,
+body {
+    height: auto;
+}
+
+#content {
+    margin: 0 5px;
+}
+
+#container {
+    margin: 0;
+    min-width: 240px !important;
+}
+
+#branding {
+    display: none;
+}
+
+.login #branding {
+    display: block;
+}
+
+#user-tools {
+    position: relative;
+    text-align: center;
+}
 
 // general
 .module {
-	border: none; box-shadow: none; padding: 5px 0 5px 0 !important;
-	@include box-shadow(none !important);
-	caption { margin-bottom: 5px; margin-left: 5px; }
+    border: none;
+    box-shadow: none;
+    padding: 5px 0 5px 0 !important;
+    @include box-shadow(none !important);
+
+    caption {
+        margin-bottom: 5px;
+        margin-left: 5px;
+    }
 }
-div.breadcrumbs { padding-left: 5px; }
-.plugin-holder { display: none !important; }
+
+div.breadcrumbs {
+    padding-left: 5px;
+}
+
+.plugin-holder {
+    display: none !important;
+}
 
 // login
 body.login {
+
 	#container {
-		width: auto !important; max-width: 320px;
+        width: auto !important;
+        max-width: 320px;
+
 		#content #content-main {
-			.form-row, .submit-row { text-align: center; }
-			.form-row input { width: auto !important; max-width: none; min-width: 40px; }
-			.submit-row input, .submit-row input[type="submit"] { width: 80% !important; }
-		}
-	}
+
+			.form-row,
+			.submit-row {
+                text-align: center;
+            }
+
+            .form-row input {
+                width: auto !important;
+                max-width: none;
+                min-width: 40px;
+            }
+
+            .submit-row input,
+			.submit-row input[type="submit"] {
+                width: 80% !important;
+            }
+        }
+    }
 }
 
 // dashboard
-.colMS { margin-right: 10px !important; }
+.colMS {
+    margin-right: 10px !important;
+}
+
 .dashboard {
+
 	#container {
-		#content h1 { display: none; }
+
+		#content h1 {
+            display: none;
+        }
+
 		#content-main {
-			min-width: 0; max-width: none; float: none;
-			.addlink, .changelink { text-indent: -9999px; overflow: hidden; }
-		}
-		#content-related { width: auto; float: none; margin-right: 0; }
+            min-width: 0;
+            max-width: none;
+            float: none;
+
+			.addlink,
+			.changelink {
+                text-indent: -9999px;
+                overflow: hidden;
+            }
+        }
+
+		#content-related {
+            width: auto;
+            float: none;
+            margin-right: 0;
+        }
+
 		#content-related .module {
-			padding: 10px !important; margin: 10px 0;
-			.actionlist { margin-left: 10px; }
-		}
-	}
-	.module { background: none !important; }
+            padding: 10px !important;
+            margin: 10px 0;
+
+			.actionlist {
+                margin-left: 10px;
+            }
+        }
+    }
+    .module {
+        background: none !important;
+    }
 }
 
 // changelist
-.change-list #content {  }
-.change-list {
-	#content {
-		.object-tools { float:right; margin: -35px 0 0 0; }
-	}
-	#toolbar {
-		label { display: inline-block; }
-		form #searchbar { width: 120px; }
-		.small { display: block; }
-	}
-	.filtered .results, .change-list .filtered .paginator, .filtered #toolbar, .filtered div.xfull {
-		margin-right: 0 !important; }
-	.module #changelist-form .results { width: 100%; overflow: auto; }
-	.filtered {
-		.actions, .paginator { margin-right: 0 !important; }
-	}
+.change-list #content {
+
 }
-#changelist-filter-button, #changelist-filter { display: none !important; }
-.tree { background: white; }
+
+.change-list {
+
+    #content {
+
+		.object-tools {
+            float: right;
+            margin: -35px 0 0 0;
+        }
+    }
+
+	#toolbar {
+
+		label {
+            display: inline-block;
+        }
+
+		form #searchbar {
+            width: 120px;
+        }
+
+		.small {
+            display: block;
+        }
+    }
+
+	.filtered .results,
+	.change-list .filtered .paginator,
+	.filtered #toolbar,
+	.filtered div.xfull {
+        margin-right: 0 !important;
+    }
+
+    .module #changelist-form .results {
+        width: 100%;
+        overflow: auto;
+    }
+
+    .filtered {
+
+        .actions,
+		.paginator {
+            margin-right: 0 !important;
+        }
+    }
+}
+
+#changelist-filter-button,
+#changelist-filter {
+    display: none !important;
+}
+
+.tree {
+    background: white;
+}
 
 // chageform
 .change-form {
-	h1 { margin-left:0; }
+
+	h1 {
+        margin-left: 0;
+    }
 }
 
 // cms language buttons
-#page_form_lang_tabs input { font-weight: normal !important; font-size: 11px !important; padding: 2px 4px !important; }
+#page_form_lang_tabs input {
+    font-weight: normal !important;
+    font-size: 11px !important;
+    padding: 2px 4px !important;
+}
+
 // nani/hvad language buttons
 .nani-language-tabs {
+
 	> span {
-		font-size: 11px !important; padding: 4px 1px !important;
-		a { padding: 3px 5px !important; }
-		.deletelink { right: 0 !important; }
-	}
+        font-size: 11px !important;
+        padding: 4px 1px !important;
+
+		a {
+            padding: 3px 5px !important;
+        }
+
+		.deletelink {
+            right: 0 !important;
+        }
+    }
+
 	> .current {
-		padding: 4px 10px 4px 5px !important;
-		.deletelink { right: -8px !important; }
-	}
+        padding: 4px 10px 4px 5px !important;
+
+		.deletelink {
+            right: -8px !important;
+        }
+    }
 }
 
 // forms
-form label, .aligned label { display: block; padding: 0 !important; float: none !important;
-	line-height: 14px; margin-top: 5px; width: auto; }
+form label,
+.aligned label {
+    display: block;
+    padding: 0 !important;
+    float: none !important;
+    line-height: 14px;
+    margin-top: 5px;
+    width: auto;
+}
+
 form {
-	input, input[type="file"], textarea, select { width: auto; /*max-width: 200px;*/ }
-	.vTextField { width: auto; }
-	.aligned p, .aligned ul { padding-left: 0 !important; margin-left: 0 !important; }
-	.submit-row { text-align: left; }
+
+    input,
+	input[type="file"],
+	textarea,
+	select {
+        width: auto;
+        /*max-width: 200px;*/
+    }
+    .vTextField {
+        width: auto;
+    }
+
+    .aligned p,
+	.aligned ul {
+        padding-left: 0 !important;
+        margin-left: 0 !important;
+    }
+
+    .submit-row {
+        text-align: left;
+    }
 }
 
 // inlines
 .inline-group {
-	padding: 5px; margin-bottom: 10px;
+    padding: 5px;
+    margin-bottom: 10px;
+
 	.module {
-		h2 { padding-left: 5px; }
-	}
+
+	    h2 {
+            padding-left: 5px;
+        }
+    }
 }
 
 // filter horizontal m2m
 .selector {
-	width: auto; float: none;
-	.selector-available, .selector-chosen {
-		width: auto; float: none;
-		p { text-align: center; }
-	}
-	.selector-chosen { margin-top: 60px; }
-	ul.selector-chooser { margin-top: 0; display: block; }
-	select[multiple], select { max-width: none; width: 100%; }
-	label { display: inline-block; }
-	.selector-available input, .selector-chosen input { width: auto; }
+    width: auto;
+    float: none;
+
+	.selector-available,
+	.selector-chosen {
+        width: auto;
+        float: none;
+
+		p {
+            text-align: center;
+        }
+    }
+
+    .selector-chosen {
+        margin-top: 60px;
+    }
+
+    ul.selector-chooser {
+        margin-top: 0;
+        display: block;
+    }
+
+    select[multiple],
+	select {
+        max-width: none;
+        width: 100%;
+    }
+
+    label {
+        display: inline-block;
+    }
+
+    .selector-available input,
+	.selector-chosen input {
+        width: auto;
+    }
 }
 
 // shortcuts
-.admin_shortcuts .shortcuts li a { background-size:20px 20px; padding:10px 10px 10px 40px; }
-.admin_shortcuts .shortcuts li a span { padding:0 !important; }
-.admin_shortcuts .shortcuts li:first-child a { padding:10px 20px; }
+.admin_shortcuts .shortcuts li a {
+    background-size: 20px 20px;
+    padding: 10px 10px 10px 40px;
+}
+
+.admin_shortcuts .shortcuts li a span {
+    padding: 0 !important;
+}
+
+.admin_shortcuts .shortcuts li:first-child a {
+    padding: 10px 20px;
+}

--- a/djangocms_admin_style/sass/partials/_shortcuts.scss
+++ b/djangocms_admin_style/sass/partials/_shortcuts.scss
@@ -1,16 +1,40 @@
 // django-admin-shortcuts
 .admin_shortcuts .shortcuts {
-	@include box-shadow(none); background: $background-color-dark; border-top: 1px solid $line-color-dark;
-	color: $font-color-ultralight;
-	h2 { border: none; font-weight: normal; }
-	li {
-		a, a:link, a:visited {
-			background-color: $background-color-medium; border: 1px solid $line-color-dark; text-decoration: none;
-			.count { color: $font-color-light; }
-			.count_new { background: $button-blue-medium-color; border-color: $button-blue-light-color; }
-		}
-		a:hover, a:focus { background-color: #4e5359; }
-		a:active { background-color: $background-color-medium; }
-	}
-}
+    @include box-shadow(none);
+    background: $background-color-dark;
+    border-top: 1px solid $line-color-dark;
+    color: $font-color-ultralight;
 
+	h2 {
+        border: none;
+        font-weight: normal;
+    }
+
+	li {
+        a,
+		a:link,
+		a:visited {
+            background-color: $background-color-medium;
+            border: 1px solid $line-color-dark;
+            text-decoration: none;
+
+			.count {
+                color: $font-color-light;
+            }
+
+			.count_new {
+                background: $button-blue-medium-color;
+                border-color: $button-blue-light-color;
+            }
+        }
+
+        a:hover,
+		a:focus {
+            background-color: #4e5359;
+        }
+
+        a:active {
+            background-color: $background-color-medium;
+        }
+    }
+}

--- a/djangocms_admin_style/sass/partials/_tables.scss
+++ b/djangocms_admin_style/sass/partials/_tables.scss
@@ -1,20 +1,72 @@
 table {
-	@include border-radius(); background: $background-color-white; border: none;
-	margin: 20px 0; padding: 5px; width: 100%;
-	th { border-bottom: 1px solid $line-color-light; }
-	th, td { padding: 5px 10px; text-align: left; vertical-align: middle; }
-	thead th, thead th.sorted, tfoot td { background: $background-color-ultralight; }
-	thead th.sortable:hover { background: $background-color-light; }
-	td, th { font-family: $base-font-family; padding: 5px; }
-	td.original { vertical-align: top; }
-	tr {
-		td { border-bottom: 1px solid $line-color-ultralight; }
-	}
+    @include border-radius;
+    background: $background-color-white;
+    border: none;
+    margin: 20px 0;
+    padding: 5px;
+    width: 100%;
+
 	th {
-		a, a:link, a:visited, a:link:visited { color: $font-color; }
-	}
-	.row1 { background: $background-color-white; }
-	.row2 { background: $background-color-ultralight; }
+        border-bottom: 1px solid $line-color-light;
+    }
+
+    th,
+	td {
+        padding: 5px 10px;
+        text-align: left;
+        vertical-align: middle;
+    }
+
+    thead th,
+	thead th.sorted,
+	tfoot td {
+        background: $background-color-ultralight;
+    }
+
+    thead th.sortable:hover {
+        background: $background-color-light;
+    }
+
+    td,
+	th {
+        font-family: $base-font-family;
+        padding: 5px;
+    }
+
+    td.original {
+        vertical-align: top;
+    }
+
+    tr {
+
+        td {
+            border-bottom: 1px solid $line-color-ultralight;
+        }
+    }
+
+    th {
+
+        a,
+		a:link,
+		a:visited,
+		a:link:visited {
+            color: $font-color;
+        }
+    }
+
+    .row1 {
+        background: $background-color-white;
+    }
+	
+    .row2 {
+        background: $background-color-ultralight;
+    }
 }
-fieldset table { border: none; }
-.results table tbody tr:hover { background: $background-color-highlighter; }
+
+fieldset table {
+    border: none;
+}
+
+.results table tbody tr:hover {
+    background: $background-color-highlighter;
+}


### PR DESCRIPTION
Began changing CSS writing styles; since this uses Sass **I see no reason for the properties of most selectors in this repository to have their properties and values on a single line** in the Sass files when Compass is set to compress the code during the process. Ergo, for ease of reading and writing, I hereby suggest that the Sass code be a lot more readable for those developing with the styles.

**Edit:** Will continue to do this with other Sass files until it is cleaned up of this.