### PR TITLE
renames back to link name

### DIFF
--- a/djangocms_admin_style/templates/admin/inc/branding.html
+++ b/djangocms_admin_style/templates/admin/inc/branding.html
@@ -23,7 +23,7 @@
 </ul>
 <div id="header-btn">
     <a href="/" class="icon-arrow-right btn js-header-link">
-        {% trans 'Back to' %} {{ request.site.name|default:_('example.com') }}
+        {% trans 'Open' %} {{ request.site.name|default:_('example.com') }}
     </a>
 </div>
 


### PR DESCRIPTION
**This pull request fixes the following issues**:

|BEFORE|AFTER|
|---|---|
|![screen shot 2015-10-23 at 16 56 24](https://cloud.githubusercontent.com/assets/2270884/10696291/32db2b46-79a7-11e5-9a2a-b0d6ace1fdd0.png)|![screen shot 2015-10-23 at 16 56 15](https://cloud.githubusercontent.com/assets/2270884/10696293/3632365e-79a7-11e5-9aec-39aa06a2f90e.png)|

