### PR TITLE
Remove obsolete load url from future

### DIFF
--- a/djangocms_admin_style/templates/admin/delete_confirmation.html
+++ b/djangocms_admin_style/templates/admin/delete_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block bodyclass %}delete-confirmation{% endblock %}

--- a/djangocms_admin_style/templates/admin/delete_selected_confirmation.html
+++ b/djangocms_admin_style/templates/admin/delete_selected_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n l10n %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block bodyclass %}delete-confirmation{% endblock %}


### PR DESCRIPTION
`` load url from future`` is no longer required since Django 1.5 and removed in Django 1.9, we can drop it