### PR TITLE
adds documentation link to dropdown

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 ------------------
 
 * Adds cancel link to delete confirmation page
+* Adds documentation link to dropdown
 
 1.1.0 (2016-02-01)
 ------------------

--- a/djangocms_admin_style/templates/admin/inc/branding.html
+++ b/djangocms_admin_style/templates/admin/inc/branding.html
@@ -15,6 +15,7 @@
                         <a href="{{ docsroot }}">{% trans 'Documentation' %}</a>
                     {% endif %}
                 </li>
+                <li class="toolbar-item-navigation-break">-----</li>
             {% endif %}
             {% if user.has_usable_password %}
                 <li>

--- a/djangocms_admin_style/templates/admin/inc/branding.html
+++ b/djangocms_admin_style/templates/admin/inc/branding.html
@@ -8,6 +8,14 @@
     <li>
         <a class="menu-item" href="">{{ site_header|default:_('Django Administration') }}</a>
         <ul class="submenu">
+            {% if user.is_active and user.is_staff %}
+                <li>
+                    {% url 'django-admindocs-docroot' as docsroot %}
+                    {% if docsroot %}
+                        <a href="{{ docsroot }}">{% trans 'Documentation' %}</a>
+                    {% endif %}
+                </li>
+            {% endif %}
             {% if user.has_usable_password %}
                 <li>
                     <a href="{% url 'admin:password_change' %}">{% trans 'Change password' %}</a>


### PR DESCRIPTION
**This pull request fixes the following issues**:

|BEFORE|AFTER|
|---|---|
|![screen shot 2016-04-06 at 14 10 00](https://cloud.githubusercontent.com/assets/2270884/14316105/7a70a03a-fc01-11e5-8fa7-f50a17e2dd60.png)|![screen shot 2016-04-06 at 14 10 33](https://cloud.githubusercontent.com/assets/2270884/14316111/7e210bde-fc01-11e5-8677-d762579eeb65.png)|
