### PR TITLE
fixes adding missing labels in datetime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Fixes input and textarea fields in not aligned inline groups
 * Fixes select field width in table
+* Adding missing labels to datetime
 
 1.2.3 (2016-06-22)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ CHANGELOG
 
 * Fixes input and textarea fields in not aligned inline groups
 * Fixes select field width in table
-* Adding missing labels to datetime
+* Added missing labels to datetime fields that are already part of the field box
 
 1.2.3 (2016-06-22)
 ------------------

--- a/djangocms_admin_style/static/djangocms_admin_style/js/datetimefields.js
+++ b/djangocms_admin_style/static/djangocms_admin_style/js/datetimefields.js
@@ -28,7 +28,7 @@
     /**
      * @function hasClass
      * @param {Element} element
-     * @param {String} className
+     * @param {String} className only accepts single classname
      * @returns {Boolean}
      */
     function hasClass(element, className) {
@@ -78,7 +78,7 @@
 
     /**
      * Wraps each date and time input inside of ".datetime" into own
-     * field boxes.
+     * field boxes. But not the ones that already have ".field-box" as a parent somewhere up the tree.
      *
      * @function reorganizeMarkup
      */
@@ -87,6 +87,16 @@
 
         dateTimeFields.forEach(function (field) {
             var closestBox = closest(field, 'field-box');
+            var closestDateTime = closest(field, 'datetime');
+            var closestBoxToDateTime;
+
+            if (closestDateTime) {
+                closestBoxToDateTime = closest(closestDateTime, 'field-box');
+            }
+
+            if (closestBoxToDateTime && closestBoxToDateTime === closestBox) {
+                return;
+            }
 
             if (!closestBox) {
                 var parent = field.parentNode;
@@ -123,7 +133,15 @@
         var dateTimeFields = getDateTimeFields();
 
         dateTimeFields.forEach(function (field) {
-            var closestBox = closest(field, 'field-box');
+            var closestBox = closest(field, 'datetime');
+
+            if (!closestBox) {
+                closestBox = closest(field, 'field-box');
+            }
+
+            if (!closestBox) {
+                return;
+            }
 
             arrayFrom(closestBox.childNodes).forEach(function (node) {
                 if (node.nodeType === Node.TEXT_NODE && node.textContent.trim() !== '') {

--- a/djangocms_admin_style/static/djangocms_admin_style/js/datetimefields.js
+++ b/djangocms_admin_style/static/djangocms_admin_style/js/datetimefields.js
@@ -28,7 +28,7 @@
     /**
      * @function hasClass
      * @param {Element} element
-     * @param {String} className only accepts single classname
+     * @param {String} className only accepts single class name
      * @returns {Boolean}
      */
     function hasClass(element, className) {


### PR DESCRIPTION
**This pull request fixes the following issues**:

|BEFORE|AFTER|
|---|---|
|![screen shot 2016-06-28 at 16 52 18](https://cloud.githubusercontent.com/assets/2270884/16420213/d0e07c7a-3d50-11e6-8666-b4f9456acc4a.png)|![screen shot 2016-06-28 at 16 52 40](https://cloud.githubusercontent.com/assets/2270884/16420227/dde6d7d4-3d50-11e6-9c8c-90d1cbab3afa.png)|


