### PR TITLE
new django-select2 integration #383

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 1.2.7 (unreleased)
 ------------------
 
+* Adjusted styles of the new version of django-select2
 * Fixes display issues when using django-nested-admin
 * Moved testing infrastructure to a centralised location ``/tests``
 * Removed object tools background and shadow in modal windows

--- a/djangocms_admin_style/sass/components/_forms.scss
+++ b/djangocms_admin_style/sass/components/_forms.scss
@@ -425,6 +425,25 @@ form {
                 box-shadow: none;
             }
         }
+        &.select2-container--default .select2-selection--single {
+            border: 1px solid $gray-lighter;
+            border-radius: $border-radius-base;
+            height: 36px;
+            line-height: 36px;
+
+            .select2-selection__arrow {
+                height: 36px;
+            }
+
+            .select2-selection__rendered {
+                font-size: $font-size-small;
+                line-height: 34px;
+
+                .select2-selection__clear {
+                    line-height: 36px;
+                }
+            }
+        }
         .select2-choice {
             line-height: 22px;
             height: 22px;
@@ -469,6 +488,9 @@ form {
             }
         }
     }
+}
+.select2-dropdown {
+    border-color: $gray-lighter !important;
 }
 .select2-drop-active {
     border: 1px solid $gray-lighter !important;


### PR DESCRIPTION
I didn't check the old version of django-select2 but If I see correctly, they have different style class names. So I kept the old styles. Here you can see the last view of django-select2:

![djangocms-admin-style](https://cloud.githubusercontent.com/assets/72323/21330456/2bc260ee-c646-11e6-91c7-212d3e85486a.png)
