### PR TITLE
Fix size of unknown state icon

### DIFF
--- a/djangocms_admin_style/sass/components/_base.scss
+++ b/djangocms_admin_style/sass/components/_base.scss
@@ -329,7 +329,8 @@ ul.messagelist {
 }
 // set image size to show retina images with correct size #212
 img[src*="icon-no"],
-img[src*="icon-yes"] {
+img[src*="icon-yes"],
+img[src*="icon-unknown"] {
     width: 16px;
     height: 16px;
 }


### PR DESCRIPTION
Fixes this bug:
![Bug example](http://chronial.de/misc/screenshots/firefox_2017-03-12_18-06-39.png)