### PR TITLE
Bumped version to 1.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.3.0 (unreleased)
+1.3.0 (2019-01-23)
 ==================
 
 * Added support for Django 1.11, 2.0 and 2.1

--- a/djangocms_admin_style/__init__.py
+++ b/djangocms_admin_style/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.2.9'
+__version__ = '1.3.0'


### PR DESCRIPTION
* Added support for Django 1.11, 2.0 and 2.1
* Removed support for Django 1.8, 1.9
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.5 and 3.6
* Added isort and adapted imports
* Adapted code base to align with other supported addons