### PR TITLE
changed "staticfiles" to "static"

### DIFF
--- a/djangocms_admin_style/templates/admin/base_site.html
+++ b/djangocms_admin_style/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-{% load i18n staticfiles admin_style_tags %}
+{% load i18n static admin_style_tags %}
 
 {% block extrastyle %}{% include 'admin/inc/extrastyle.html' %}{% endblock %}
 


### PR DESCRIPTION
As of django 3.x "staticfiles" keyword has been deprecated, and instead of that only "static" keyword is being used.